### PR TITLE
Move board.sqlite to local storage and rename tasks directory

### DIFF
--- a/ISSUES.MD
+++ b/ISSUES.MD
@@ -1,7 +1,7 @@
 # File Sync Error When Downloading Job Folder
 
 ## Architecture Overview
-- **taintedpaint** provides the Next.js web interface and REST API. Job files are saved under `storage/tasks`. Metadata is tracked in `storage/metadata.json`.
+- **taintedpaint** provides the Next.js web interface and REST API. Job files are saved under `storage/项目`. Metadata is tracked in `storage/metadata.json`.
 - **blackpaint** is the Electron wrapper (Estara). When the Kanban drawer's "Open" button is used, the Electron main process downloads the job's files to the user's `Downloads` directory and starts a bidirectional sync (`startBidirectionalSync` in `blackpaint/src/sync.ts`).
 
 ## Problem Description

--- a/file-sync.md
+++ b/file-sync.md
@@ -2,7 +2,7 @@
 
 Estara no longer performs background file synchronisation. The simplified workflow is:
 
-1. **Upload** – A new job is created by uploading a folder through the web UI (`POST /api/jobs`). The server stores the folder under `storage/tasks/<taskId>`.
+1. **Upload** – A new job is created by uploading a folder through the web UI (`POST /api/jobs`). The server stores the folder under `storage/项目/<taskId>`.
 2. **Download** – From the Kanban drawer the desktop app downloads the current files with `download-and-open-task-folder` and opens the folder on disk.
 3. **Replace** – After editing locally, select a new folder and upload it via `POST /api/jobs/<taskId>/replace`. The server removes the old files and saves the new upload.
 

--- a/issues-ebusy-reopening.md
+++ b/issues-ebusy-reopening.md
@@ -1,7 +1,7 @@
 # EBUSY Error When Reopening Downloaded Job
 
 ## Architecture Overview
-- **taintedpaint** is the Next.js server and web UI. Task files live under `storage/tasks/{taskId}`.
+- **taintedpaint** is the Next.js server and web UI. Task files live under `storage/项目/{taskId}`.
 - **blackpaint (Estara)** downloads a task's files to `C:\EstaraSync/<Folder>` on Windows (or `~/Desktop/Estara 数据/<Folder>` on other platforms) and starts `startBidirectionalSync` from `blackpaint/src/sync.ts`.
 
 ## What Happened

--- a/issues-invalid-url-download.md
+++ b/issues-invalid-url-download.md
@@ -1,7 +1,7 @@
 # Download Fails with Invalid URL Error
 
 ## Architecture Overview
-- **taintedpaint** hosts the Next.js API routes and serves uploaded files from `storage/tasks/{taskId}`.
+- **taintedpaint** hosts the Next.js API routes and serves uploaded files from `storage/项目/{taskId}`.
 - **blackpaint** is the Electron client (Estara). The Kanban drawer calls `downloadAndOpenTaskFolder` which retrieves `/api/jobs/{taskId}/files`, downloads each entry and starts sync.
 
 ## Problem

--- a/issues-local-delete-on-missing-server-folder.md
+++ b/issues-local-delete-on-missing-server-folder.md
@@ -1,7 +1,7 @@
 # Local Files Deleted When Server Folder Missing
 
 ## Architecture Recap
-- **taintedpaint** hosts uploaded files under `storage/tasks/<taskId>`.
+- **taintedpaint** hosts uploaded files under `storage/项目/<taskId>`.
 - **blackpaint** downloads a task's folder and keeps it in sync via `startBidirectionalSync` in `blackpaint/src/sync.ts`.
 
 ## What Happened

--- a/issues-missing-files-after-upload.md
+++ b/issues-missing-files-after-upload.md
@@ -1,7 +1,7 @@
 # Files Disappear After Syncing on Another Client
 
 ## Architecture Recap
-- **taintedpaint** stores uploaded job files under `storage/tasks/{taskId}`.
+- **taintedpaint** stores uploaded job files under `storage/项目/{taskId}`.
 - **blackpaint** downloads a job's files locally and runs `startBidirectionalSync` from `blackpaint/src/sync.ts`.
 
 ## What Happened

--- a/issues-nested-folders-sync.md
+++ b/issues-nested-folders-sync.md
@@ -1,14 +1,14 @@
 # Nested Folders Reappear in Downloads
 
 ## Architecture and Workflow Overview
-- **taintedpaint** serves as the Next.js web interface and provides REST API routes for file management. Uploaded jobs are stored under `storage/tasks/{taskId}`.
+- **taintedpaint** serves as the Next.js web interface and provides REST API routes for file management. Uploaded jobs are stored under `storage/项目/{taskId}`.
 - **blackpaint (Estara)** is the Electron shell. When the user clicks *Open* in the Kanban drawer it downloads all job files to `~/Downloads/{folderName}` and starts a bidirectional sync via `startBidirectionalSync`.
 
 ## Problem
 When uploading a folder through the web interface each file is sent with its `webkitRelativePath`. This path includes the root folder name. The server stored the files exactly as received (e.g. `task-123/partA.pdf`). When Estara later downloaded the job it also created a folder named after the job (e.g. `YNMX-001`). Because the stored paths already contained the top level directory, the downloaded folder ended up containing another copy of the root (e.g. `YNMX-001/task-123/partA.pdf`). If the user deleted the extra subfolder locally it was recreated on the next sync because the server kept that prefix.
 
 ## Fix
-Strip the uploaded root folder name from each file path on the server. The `POST /api/jobs` route now removes the `folderName` prefix from every `filePaths` entry before saving. Newly created tasks therefore store files directly under `storage/tasks/{taskId}` without the extra subdirectory.
+Strip the uploaded root folder name from each file path on the server. The `POST /api/jobs` route now removes the `folderName` prefix from every `filePaths` entry before saving. Newly created tasks therefore store files directly under `storage/项目/{taskId}` without the extra subdirectory.
 
 ## Result
 Opening a job in Estara now downloads files directly into the job folder without nesting. Deleting local folders no longer results in them reappearing from the server.

--- a/issues-pending-upload-cross-sync.md
+++ b/issues-pending-upload-cross-sync.md
@@ -1,7 +1,7 @@
 # Folder from Another Job Appears Inside a Task
 
 ## Architecture Recap
-- **taintedpaint** (Next.js web UI & API) stores uploaded job files under `storage/tasks/{taskId}`. Metadata about tasks lives in `storage/metadata.json`.
+- **taintedpaint** (Next.js web UI & API) stores uploaded job files under `storage/项目/{taskId}`. Metadata about tasks lives in `storage/metadata.json`.
 - **blackpaint** (Electron client "Estara") downloads a job's files to the user's `Downloads/{folderName}` and runs `startBidirectionalSync` from `blackpaint/src/sync.ts` to keep local and remote files in sync.
 
 ## Problem

--- a/issues-slow-task-downloads.md
+++ b/issues-slow-task-downloads.md
@@ -1,7 +1,7 @@
 # Slow Download When Opening Job Folder
 
 ## Architecture Overview
-- **taintedpaint** serves the Next.js UI and API. Task files are stored under `storage/tasks/{taskId}` and listed via `/api/jobs/[taskId]/files`.
+- **taintedpaint** serves the Next.js UI and API. Task files are stored under `storage/项目/{taskId}` and listed via `/api/jobs/[taskId]/files`.
 - **blackpaint** is the Electron wrapper (Estara). The Kanban drawer invokes `downloadAndOpenTaskFolder` which downloads each listed file and then starts bidirectional sync.
 
 ## Problem

--- a/issues-temp-files-and-empty-dirs.md
+++ b/issues-temp-files-and-empty-dirs.md
@@ -1,7 +1,7 @@
 # LCK/BAK Files and Missing Empty Directories
 
 ## Architecture
-- **taintedpaint** runs the Next.js API. Task files live under `storage/tasks/<taskId>` and are listed through `/api/jobs/[taskId]/files`.
+- **taintedpaint** runs the Next.js API. Task files live under `storage/项目/<taskId>` and are listed through `/api/jobs/[taskId]/files`.
 - **blackpaint (Estara)** downloads a job's folder then keeps it in sync via `startBidirectionalSync` in `blackpaint/src/sync.ts`.
 
 ## Problem

--- a/issues.md
+++ b/issues.md
@@ -1,7 +1,7 @@
 # File Sync Error When Downloading Job Folder
 
 ## Architecture Overview
-- **taintedpaint** provides the Next.js web interface and REST API. Job files are saved under `storage/tasks`. Metadata is tracked in `storage/metadata.json`.
+- **taintedpaint** provides the Next.js web interface and REST API. Job files are saved under `storage/项目`. Metadata is tracked in `storage/metadata.json`.
 - **blackpaint** is the Electron wrapper (Estara). When the Kanban drawer's "Open" button is used, the Electron main process downloads the job's files to the user's `Downloads` directory and starts a bidirectional sync (`startBidirectionalSync` in `blackpaint/src/sync.ts`).
 
 ## Problem Description

--- a/relevant-issue-name.md
+++ b/relevant-issue-name.md
@@ -1,11 +1,11 @@
 # Storage Folder Reappears After Deletion
 
 ## Architecture Overview
-- **taintedpaint** hosts the Next.js web app and REST API. Uploaded tasks are saved under `storage/tasks/<taskId>` and metadata lives in `storage/metadata.json`.
+- **taintedpaint** hosts the Next.js web app and REST API. Uploaded tasks are saved under `storage/项目/<taskId>` and metadata lives in `storage/metadata.json`.
 - **blackpaint** is the Electron client (*Estara*). When a task is opened it downloads files locally and starts a bidirectional sync via `startBidirectionalSync` in `blackpaint/src/sync.ts`.
 
 ## Why deleted server files return
-When the server's `/storage` directory is removed, any running Estara clients still think their tasks exist. The sync process lists files locally and uploads missing ones to the server every 10 seconds. The upload route (`app/api/jobs/[taskId]/upload/route.ts`) previously wrote files to disk before checking that the task was still present in `metadata.json`. As a result, clients recreated `/storage/tasks/<taskId>` even though the metadata file was gone.
+When the server's `/storage` directory is removed, any running Estara clients still think their tasks exist. The sync process lists files locally and uploads missing ones to the server every 10 seconds. The upload route (`app/api/jobs/[taskId]/upload/route.ts`) previously wrote files to disk before checking that the task was still present in `metadata.json`. As a result, clients recreated `/storage/项目/<taskId>` even though the metadata file was gone.
 
 ## Temporary metadata files
 `lib/boardDataStore.ts` writes updates using a lock file and a temporary path like `metadata.json.<uuid>.tmp` before renaming it to `metadata.json`.

--- a/taintedpaint/app/api/jobs/[taskId]/files/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/files/route.ts
@@ -43,7 +43,7 @@ async function getFilesRecursively(directory: string, basePath: string, baseUrl:
       const urlPathParts = relativePath.split(path.sep).map(part => encodeURIComponent(part));
       const encodedRelativePath = urlPathParts.join('/');
       
-      const url = `${baseUrl}/storage/tasks/${path.basename(basePath)}/${encodedRelativePath}`;
+      const url = `${baseUrl}/storage/项目/${path.basename(basePath)}/${encodedRelativePath}`;
 
       fileList.push({
         filename: entry.name,

--- a/taintedpaint/app/api/jobs/route.ts
+++ b/taintedpaint/app/api/jobs/route.ts
@@ -11,7 +11,7 @@ import type { BoardData, Task } from "@/types";
 import { baseColumns, START_COLUMN_ID } from "@/lib/baseColumns";
 import { readBoardData, updateBoardData } from "@/lib/boardDataStore";
 import { invalidateFilesCache } from "@/lib/filesCache";
-import { STORAGE_ROOT, TASKS_STORAGE_DIR } from "@/lib/storagePaths";
+import { STORAGE_ROOT, TASKS_STORAGE_DIR, TASKS_DIR_NAME } from "@/lib/storagePaths";
 
 // --- Path Definitions ---
 // Files are stored on a shared network disk. Configure the root path with the
@@ -152,7 +152,7 @@ export async function POST(req: NextRequest) {
       ynmxId: ynmxId.trim() || undefined,
       // Store the relative path inside the SMB share so clients can resolve it
       // using their own mounted location.
-      taskFolderPath: `tasks/${taskId}`,
+      taskFolderPath: `${TASKS_DIR_NAME}/${taskId}`,
       files: [folderName],
     };
 

--- a/taintedpaint/lib/boardDataStore.ts
+++ b/taintedpaint/lib/boardDataStore.ts
@@ -1,14 +1,13 @@
 import { mkdirSync } from 'fs'
-import path from 'path'
-import { STORAGE_ROOT } from './storagePaths'
+import { BOARD_DB_PATH, LOCAL_STORAGE_ROOT } from './storagePaths'
 import Database from 'better-sqlite3'
 import { baseColumns, START_COLUMN_ID, ARCHIVE_COLUMN_ID } from './baseColumns'
 import type { BoardData } from '@/types'
 
 // Store dynamic data outside of the public directory so it remains
 // accessible when running `npm run build && npm run start`.
-const STORAGE_DIR = STORAGE_ROOT
-const DB_PATH = path.join(STORAGE_DIR, 'board.sqlite')
+const STORAGE_DIR = LOCAL_STORAGE_ROOT
+const DB_PATH = BOARD_DB_PATH
 
 mkdirSync(STORAGE_DIR, { recursive: true })
 

--- a/taintedpaint/lib/storagePaths.ts
+++ b/taintedpaint/lib/storagePaths.ts
@@ -1,4 +1,7 @@
-import path from 'path';
+import path from 'path'
 
-export const STORAGE_ROOT = process.env.SMB_ROOT || path.join(process.cwd(), '..', 'storage');
-export const TASKS_STORAGE_DIR = path.join(STORAGE_ROOT, 'tasks');
+export const LOCAL_STORAGE_ROOT = path.join(process.cwd(), '..', 'storage')
+export const STORAGE_ROOT = process.env.SMB_ROOT || LOCAL_STORAGE_ROOT
+export const TASKS_DIR_NAME = '项目'
+export const TASKS_STORAGE_DIR = path.join(STORAGE_ROOT, TASKS_DIR_NAME)
+export const BOARD_DB_PATH = path.join(LOCAL_STORAGE_ROOT, 'board.sqlite')


### PR DESCRIPTION
## Summary
- store board database under repo-local `storage` instead of SMB share
- rename shared tasks folder to `项目`
- adjust API routes and constants for new directory
- update documentation for new path

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688885fabea8832fad9cdd4299f5b3b0