### PR TITLE
Add '批量' column to kanban

### DIFF
--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -73,6 +73,7 @@ export default function KanbanBoard() {
     program: 'bg-indigo-500',
     operate: 'bg-cyan-500',
     manual: 'bg-pink-500',
+    batch: 'bg-fuchsia-500',
     surface: 'bg-rose-500',
     inspect: 'bg-lime-500',
     ship: 'bg-green-500',
@@ -509,7 +510,7 @@ export default function KanbanBoard() {
 
   const visibleColumns = useMemo(() => {
     if (viewMode === 'production') {
-      return columns.filter(c => ['approval', 'outsourcing', 'daohe', 'program', 'operate', 'manual', 'surface', 'inspect', 'ship', 'archive2'].includes(c.id))
+      return columns.filter(c => ['approval', 'outsourcing', 'daohe', 'program', 'operate', 'manual', 'batch', 'surface', 'inspect', 'ship', 'archive2'].includes(c.id))
     }
     return columns
   }, [viewMode, columns])

--- a/taintedpaint/lib/baseColumns.ts
+++ b/taintedpaint/lib/baseColumns.ts
@@ -18,6 +18,7 @@ export const baseColumns: Column[] = [
   { id: "program",     title: "编程",   taskIds: [] },
   { id: "operate",     title: "操机",   taskIds: [] },
   { id: "manual",      title: "手工",   taskIds: [] },
+  { id: "batch",       title: "批量",   taskIds: [] },
   { id: "surface",     title: "表面处理",   taskIds: [] },
   { id: "inspect",     title: "检验",   taskIds: [] },
   { id: "ship",        title: "出货",   taskIds: [] },


### PR DESCRIPTION
## Summary
- expand the column list with a new `批量` column
- support new column color in the board UI
- include `批量` column in production view filtering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688985558900832faa2806ec6dd62383