### PR TITLE
Fix type mismatch for date picker refs

### DIFF
--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -92,7 +92,9 @@ export default function KanbanBoard() {
   const searchInputRef = useRef<HTMLInputElement>(null)
   const searchStartDateInputRef = useRef<HTMLInputElement>(null)
   const searchEndDateInputRef = useRef<HTMLInputElement>(null)
-  const openSearchDatePicker = (ref: React.RefObject<HTMLInputElement>) => {
+  const openSearchDatePicker = (
+    ref: React.RefObject<HTMLInputElement | null>,
+  ) => {
     const input = ref.current
     if (!input) return
     if ((input as any).showPicker) {


### PR DESCRIPTION
## Summary
- allow nullable refs when opening the search date picker

## Testing
- `npm test`
- `npm run build` *(fails: next not found due to missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_6889f69450dc832faa2eeb168a8ff2bd