### PR TITLE
feat: void archive column

### DIFF
--- a/taintedpaint/app/api/search/route.ts
+++ b/taintedpaint/app/api/search/route.ts
@@ -15,6 +15,7 @@ export async function GET(req: NextRequest) {
     const colMap = new Map(data.columns.map((c) => [c.id, c.title]));
     const results = Object.values(data.tasks as Record<string, Task>)
       .filter((task) => {
+        if (task.columnId === 'archive' || task.columnId === 'archive2') return false;
         const text = `${task.customerName} ${task.representative} ${task.ynmxId ?? ''} ${task.notes ?? ''}`.toLowerCase();
         return text.includes(query);
       })

--- a/taintedpaint/lib/boardDataStore.ts
+++ b/taintedpaint/lib/boardDataStore.ts
@@ -30,12 +30,23 @@ function normalizeBoardData(data: BoardData) {
   const columnIds = new Set(columnMap.keys())
   const archiveCol = columnMap.get(ARCHIVE_COLUMN_ID) || data.columns[0]
 
-  // Remove unknown taskIds from columns
+  // Remove unknown and archived taskIds from columns
   for (const col of data.columns) {
-    col.taskIds = Array.from(new Set(col.taskIds.filter(id => id in data.tasks)))
+    col.taskIds = Array.from(
+      new Set(
+        col.taskIds.filter(id => {
+          const t = (data.tasks as Record<string, any>)[id]
+          return t && t.columnId !== ARCHIVE_COLUMN_ID && t.columnId !== 'archive2'
+        })
+      )
+    )
   }
 
   for (const [id, task] of Object.entries(data.tasks)) {
+    if (task.columnId === ARCHIVE_COLUMN_ID || task.columnId === 'archive2') {
+      delete data.tasks[id]
+      continue
+    }
     if (!columnIds.has(task.columnId)) {
       task.columnId = ARCHIVE_COLUMN_ID
     }


### PR DESCRIPTION
## Summary
- remove tasks when dropped on archive columns so archive remains empty
- exclude archived tasks from board and API search
- normalize board data to purge archived tasks entirely

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894782595d0832f955b6449bbe209db