### PR TITLE
feat: add pending acceptance flow for tasks

### DIFF
--- a/taintedpaint/types.ts
+++ b/taintedpaint/types.ts
@@ -13,6 +13,8 @@ export interface Task {
   files?: string[];
   ynmxId?: string; // ID assigned when moving to approval
   deliveryNoteGenerated?: boolean;
+  awaitingAcceptance?: boolean;
+  previousColumnId?: string;
 }
 
 // A lightweight version used for the Kanban overview
@@ -26,6 +28,8 @@ export interface TaskSummary {
   notes: string;
   ynmxId?: string;
   deliveryNoteGenerated?: boolean;
+  awaitingAcceptance?: boolean;
+  previousColumnId?: string;
 }
 
 export interface Column {


### PR DESCRIPTION
## Summary
- add awaitingAcceptance and previousColumnId fields to tasks
- route dropped tasks through pending acceptance with UI to accept or decline

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894b8d0eee8832fa00376029162929e