### PR TITLE
feat: add task acceptance flow to kanban

### DIFF
--- a/taintedpaint/app/api/jobs/route.ts
+++ b/taintedpaint/app/api/jobs/route.ts
@@ -35,6 +35,7 @@ export async function GET(req: NextRequest) {
         {
           id: t.id,
           columnId: t.columnId,
+          previousColumnId: t.previousColumnId,
           customerName: t.customerName,
           representative: t.representative,
           inquiryDate: t.inquiryDate,
@@ -42,6 +43,7 @@ export async function GET(req: NextRequest) {
           notes: t.notes,
           ynmxId: t.ynmxId,
           deliveryNoteGenerated: t.deliveryNoteGenerated,
+          awaitingAcceptance: t.awaitingAcceptance,
         },
       ])
     );
@@ -156,6 +158,7 @@ export async function POST(req: NextRequest) {
       taskFolderPath: `${TASKS_DIR_NAME}/${taskId}`,
       files: [folderName],
       deliveryNoteGenerated: false,
+      awaitingAcceptance: false,
     };
 
     await updateBoardData(async (boardData) => {

--- a/taintedpaint/app/holistic/page.tsx
+++ b/taintedpaint/app/holistic/page.tsx
@@ -68,14 +68,21 @@ export default function ArchivePage() {
           const data: BoardData = await res.json();
           setTasks(data.tasks || {});
           const map = new Map((data.columns || []).map(c => [c.id, c]));
-          setColumns(baseColumns.map(b => map.get(b.id) || b));
+          setColumns(
+            baseColumns.map(b => {
+              const saved = map.get(b.id);
+              return { ...b, ...saved, pendingTaskIds: saved?.pendingTaskIds || [] };
+            })
+          );
         }
       } catch {}
     })();
   }, []);
 
   const jobs = useMemo<Job[]>(() =>
-    Object.values(tasks).map(t => ({ ...t, status: getStatus(t) }))
+    Object.values(tasks)
+      .filter(t => !t.awaitingAcceptance)
+      .map(t => ({ ...t, status: getStatus(t) }))
   , [tasks]);
 
   const customers = useMemo(() => Array.from(new Set(jobs.map(j => j.customerName))), [jobs]);

--- a/taintedpaint/lib/baseColumns.ts
+++ b/taintedpaint/lib/baseColumns.ts
@@ -7,20 +7,20 @@ export const ARCHIVE_COLUMN_ID = "archive";
 
 // Updated to use taskIds
 export const baseColumns: Column[] = [
-  { id: "create",      title: "建单",   taskIds: [] },
-  { id: "quote",       title: "报价",   taskIds: [] },
-  { id: "send",        title: "发出",   taskIds: [] },
-  { id: "archive",     title: "报价归档",   taskIds: [] },
-  { id: "sheet",       title: "制单",   taskIds: [] },
-  { id: "approval",    title: "审批",   taskIds: [] },
-  { id: "outsourcing", title: "外协",   taskIds: [] },
-  { id: "daohe",      title: "道禾",   taskIds: [] },
-  { id: "program",     title: "编程",   taskIds: [] },
-  { id: "operate",     title: "操机",   taskIds: [] },
-  { id: "manual",      title: "手工",   taskIds: [] },
-  { id: "batch",       title: "批量",   taskIds: [] },
-  { id: "surface",     title: "表面处理",   taskIds: [] },
-  { id: "inspect",     title: "检验",   taskIds: [] },
-  { id: "ship",        title: "出货",   taskIds: [] },
-  { id: "archive2",    title: "完成归档",   taskIds: [] }
+  { id: "create",      title: "建单",   taskIds: [], pendingTaskIds: [] },
+  { id: "quote",       title: "报价",   taskIds: [], pendingTaskIds: [] },
+  { id: "send",        title: "发出",   taskIds: [], pendingTaskIds: [] },
+  { id: "archive",     title: "报价归档",   taskIds: [], pendingTaskIds: [] },
+  { id: "sheet",       title: "制单",   taskIds: [], pendingTaskIds: [] },
+  { id: "approval",    title: "审批",   taskIds: [], pendingTaskIds: [] },
+  { id: "outsourcing", title: "外协",   taskIds: [], pendingTaskIds: [] },
+  { id: "daohe",      title: "道禾",   taskIds: [], pendingTaskIds: [] },
+  { id: "program",     title: "编程",   taskIds: [], pendingTaskIds: [] },
+  { id: "operate",     title: "操机",   taskIds: [], pendingTaskIds: [] },
+  { id: "manual",      title: "手工",   taskIds: [], pendingTaskIds: [] },
+  { id: "batch",       title: "批量",   taskIds: [], pendingTaskIds: [] },
+  { id: "surface",     title: "表面处理",   taskIds: [], pendingTaskIds: [] },
+  { id: "inspect",     title: "检验",   taskIds: [], pendingTaskIds: [] },
+  { id: "ship",        title: "出货",   taskIds: [], pendingTaskIds: [] },
+  { id: "archive2",    title: "完成归档",   taskIds: [], pendingTaskIds: [] }
 ];

--- a/taintedpaint/types.ts
+++ b/taintedpaint/types.ts
@@ -3,6 +3,8 @@
 export interface Task {
   id: string;
   columnId: string; // <-- NEW
+  /** Previous column when awaiting acceptance */
+  previousColumnId?: string;
   customerName: string;
   representative: string;
   inquiryDate: string;
@@ -13,12 +15,15 @@ export interface Task {
   files?: string[];
   ynmxId?: string; // ID assigned when moving to approval
   deliveryNoteGenerated?: boolean;
+  /** Whether this task is waiting for acceptance in the target column */
+  awaitingAcceptance?: boolean;
 }
 
 // A lightweight version used for the Kanban overview
 export interface TaskSummary {
   id: string;
   columnId: string;
+  previousColumnId?: string;
   customerName: string;
   representative: string;
   inquiryDate: string;
@@ -26,12 +31,15 @@ export interface TaskSummary {
   notes: string;
   ynmxId?: string;
   deliveryNoteGenerated?: boolean;
+  awaitingAcceptance?: boolean;
 }
 
 export interface Column {
   id: string;
   title: string;
   taskIds: string[]; // <-- CHANGED from tasks: Task[]
+  /** Tasks waiting to be accepted for this column */
+  pendingTaskIds: string[];
 }
 
 // NEW: A type for the entire board data


### PR DESCRIPTION
## Summary
- add pending task support with accept/decline flow
- track previous column and awaiting acceptance state for tasks
- surface pending tasks in kanban UI with accept/decline controls

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6894bdceedc4832f91022b20824dd2c7