### PR TITLE
Add login and signup flow

### DIFF
--- a/blackpaint/README.md
+++ b/blackpaint/README.md
@@ -6,7 +6,7 @@ application. Two distributable versions exist:
 - **Administrator** – no restrictions, loads the web app directly.
 - **Production** – restricted view. The Electron window loads the web URL with
   `?restricted=1` appended. Inside `taintedpaint` this query param disables the
-  商务 tab and 总揽 switcher so production workers only see the 生产 section.
+  商务 tab so production workers only see the 生产 section.
 
 The build script `npm run make:restricted` sets the `RESTRICTED` environment
 variable and Webpack's `EnvironmentPlugin` embeds its value into the compiled

--- a/taintedpaint/app/api/login/route.ts
+++ b/taintedpaint/app/api/login/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { authenticateUser } from '@/lib/userStore'
+
+export async function POST(req: NextRequest) {
+  try {
+    const { name, password } = await req.json()
+    if (!name || !password) {
+      return NextResponse.json({ error: 'Invalid input' }, { status: 400 })
+    }
+    const user = await authenticateUser(name, password)
+    if (!user) {
+      return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 })
+    }
+    return NextResponse.json({ user })
+  } catch (err) {
+    return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 })
+  }
+}

--- a/taintedpaint/app/api/signup/route.ts
+++ b/taintedpaint/app/api/signup/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { addUser } from '@/lib/userStore'
+
+const DEPARTMENTS = ['商务', '编程', '手工', '操机', '表面处理', '检验']
+
+export async function POST(req: NextRequest) {
+  try {
+    const { name, department, password } = await req.json()
+    if (!name || !department || !password || !DEPARTMENTS.includes(department)) {
+      return NextResponse.json({ error: 'Invalid input' }, { status: 400 })
+    }
+    const user = await addUser(name, department, password)
+    return NextResponse.json({ user })
+  } catch (err) {
+    return NextResponse.json({ error: 'User exists' }, { status: 400 })
+  }
+}

--- a/taintedpaint/app/holistic/page.tsx
+++ b/taintedpaint/app/holistic/page.tsx
@@ -7,6 +7,7 @@
  */
 'use client';
 import { useState, useMemo, useEffect, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
 import type { Task, Column, BoardData } from '@/types';
 import { baseColumns } from '@/lib/baseColumns';
 import KanbanDrawer from '@/components/KanbanDrawer';
@@ -57,8 +58,19 @@ const statusInfo = {
 
 // ─── 主页面组件 ───────────────────────────────────────────────────────────────
 export default function ArchivePage() {
+  const router = useRouter();
+  const [ready, setReady] = useState(false);
+  useEffect(() => {
+    const user = localStorage.getItem('user');
+    if (!user) {
+      router.replace('/login');
+    } else {
+      setReady(true);
+    }
+  }, [router]);
   const [tasks, setTasks] = useState<Record<string, Task>>({});
   const [columns, setColumns] = useState<Column[]>(baseColumns);
+  if (!ready) return null;
 
   useEffect(() => {
     (async () => {

--- a/taintedpaint/app/login/page.tsx
+++ b/taintedpaint/app/login/page.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+
+export default function LoginPage() {
+  const router = useRouter()
+  const [name, setName] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+    try {
+      const res = await fetch('/api/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, password })
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setError(data.error || '登录失败')
+        return
+      }
+      localStorage.setItem('user', JSON.stringify(data.user))
+      router.push('/')
+    } catch {
+      setError('登录失败')
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <form onSubmit={handleSubmit} className="bg-white p-6 rounded shadow w-full max-w-sm space-y-4">
+        <h1 className="text-xl font-semibold text-center">登录</h1>
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+        <Input placeholder="姓名" value={name} onChange={e => setName(e.target.value)} />
+        <Input type="password" placeholder="密码" value={password} onChange={e => setPassword(e.target.value)} />
+        <Button type="submit" className="w-full">登录</Button>
+        <p className="text-sm text-center text-gray-600">
+          没有账号？ <Link href="/signup" className="text-blue-500">注册</Link>
+        </p>
+      </form>
+    </div>
+  )
+}

--- a/taintedpaint/app/page.tsx
+++ b/taintedpaint/app/page.tsx
@@ -3,7 +3,20 @@
 "use client"
 
 import KanbanBoard from "@/kanban-board"
+import { useEffect, useState } from "react"
+import { useRouter } from "next/navigation"
 
 export default function Page() {
+  const router = useRouter()
+  const [ready, setReady] = useState(false)
+  useEffect(() => {
+    const user = localStorage.getItem('user')
+    if (!user) {
+      router.replace('/login')
+    } else {
+      setReady(true)
+    }
+  }, [router])
+  if (!ready) return null
   return <KanbanBoard />
 }

--- a/taintedpaint/app/signup/page.tsx
+++ b/taintedpaint/app/signup/page.tsx
@@ -1,0 +1,62 @@
+"use client"
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+
+const DEPARTMENTS = ['商务', '编程', '手工', '操机', '表面处理', '检验']
+
+export default function SignupPage() {
+  const router = useRouter()
+  const [name, setName] = useState('')
+  const [department, setDepartment] = useState(DEPARTMENTS[0])
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+    try {
+      const res = await fetch('/api/signup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, department, password })
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setError(data.error || '注册失败')
+        return
+      }
+      localStorage.setItem('user', JSON.stringify(data.user))
+      router.push('/')
+    } catch {
+      setError('注册失败')
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <form onSubmit={handleSubmit} className="bg-white p-6 rounded shadow w-full max-w-sm space-y-4">
+        <h1 className="text-xl font-semibold text-center">注册</h1>
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+        <Input placeholder="姓名" value={name} onChange={e => setName(e.target.value)} />
+        <select
+          className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm"
+          value={department}
+          onChange={e => setDepartment(e.target.value)}
+        >
+          {DEPARTMENTS.map(dep => (
+            <option key={dep} value={dep}>{dep}</option>
+          ))}
+        </select>
+        <Input type="password" placeholder="密码" value={password} onChange={e => setPassword(e.target.value)} />
+        <Button type="submit" className="w-full">注册</Button>
+        <p className="text-sm text-center text-gray-600">
+          已有账号？ <Link href="/login" className="text-blue-500">登录</Link>
+        </p>
+      </form>
+    </div>
+  )
+}

--- a/taintedpaint/components/AccountButton.tsx
+++ b/taintedpaint/components/AccountButton.tsx
@@ -1,0 +1,60 @@
+"use client"
+
+import { useEffect, useState } from 'react'
+import { User } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+
+interface StoredUser {
+  name: string
+  department: string
+}
+
+export default function AccountButton() {
+  const [user, setUser] = useState<StoredUser | null>(null)
+  const [open, setOpen] = useState(false)
+  const router = useRouter()
+
+  useEffect(() => {
+    const stored = localStorage.getItem('user')
+    if (stored) setUser(JSON.parse(stored))
+  }, [])
+
+  const logout = () => {
+    localStorage.removeItem('user')
+    setUser(null)
+    setOpen(false)
+    router.push('/login')
+  }
+
+  if (!user) {
+    return (
+      <Link href="/login" className="p-2 hover:bg-gray-100 rounded-lg" title="登录">
+        <User className="w-5 h-5 text-gray-600" />
+      </Link>
+    )
+  }
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setOpen(!open)}
+        className="p-2 hover:bg-gray-100 rounded-lg"
+        title={user.name}
+      >
+        <User className="w-5 h-5 text-gray-600" />
+      </button>
+      {open && (
+        <div className="absolute right-0 mt-2 w-32 bg-white border border-gray-200 rounded shadow-md z-50">
+          <div className="px-4 py-2 text-sm text-gray-700 border-b border-gray-100">{user.name}</div>
+          <button
+            onClick={logout}
+            className="w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
+          >
+            退出
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -5,10 +5,10 @@ import type { Task, TaskSummary, Column, BoardData, BoardSummaryData } from "@/t
 import { useState, useEffect, useCallback, useMemo, useRef } from "react"
 import CreateJobForm from "@/components/CreateJobForm"
 import { Card } from "@/components/ui/card"
-import { Archive, Search, LayoutGrid, Lock, X, ChevronRight, RotateCw, Move, CalendarDays, Check, Plus } from "lucide-react"
-import Link from "next/link"
+import { Archive, Search, Lock, X, ChevronRight, RotateCw, Move, CalendarDays, Check, Plus } from "lucide-react"
 import { baseColumns, START_COLUMN_ID, ARCHIVE_COLUMN_ID } from "@/lib/baseColumns"
 import KanbanDrawer from "@/components/KanbanDrawer"
+import AccountButton from "@/components/AccountButton"
 
 // Skeleton component
 const TaskSkeleton = () => (
@@ -724,15 +724,7 @@ export default function KanbanBoard() {
               </kbd>
             </button>
 
-            {!restricted && (
-              <Link 
-                href="/holistic" 
-                className="flex items-center gap-2 px-3 py-1.5 text-sm text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-all"
-              >
-                <LayoutGrid className="w-4 h-4" />
-                <span>总揽</span>
-              </Link>
-            )}
+            <AccountButton />
           </div>
         </div>
       </header>

--- a/taintedpaint/lib/userStore.ts
+++ b/taintedpaint/lib/userStore.ts
@@ -1,0 +1,42 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+import crypto from 'crypto'
+import { LOCAL_STORAGE_ROOT } from './storagePaths'
+import type { User } from '@/types'
+
+const USERS_PATH = path.join(LOCAL_STORAGE_ROOT, 'users.json')
+
+async function readUsers(): Promise<User[]> {
+  try {
+    const data = await fs.readFile(USERS_PATH, 'utf8')
+    return JSON.parse(data)
+  } catch {
+    return []
+  }
+}
+
+async function writeUsers(users: User[]): Promise<void> {
+  await fs.mkdir(path.dirname(USERS_PATH), { recursive: true })
+  await fs.writeFile(USERS_PATH, JSON.stringify(users, null, 2), 'utf8')
+}
+
+export async function addUser(name: string, department: string, password: string) {
+  const users = await readUsers()
+  if (users.find(u => u.name === name)) {
+    throw new Error('User exists')
+  }
+  const passwordHash = crypto.createHash('sha256').update(password).digest('hex')
+  const user: User = { name, department, passwordHash }
+  users.push(user)
+  await writeUsers(users)
+  return { name: user.name, department: user.department }
+}
+
+export async function authenticateUser(name: string, password: string) {
+  const users = await readUsers()
+  const user = users.find(u => u.name === name)
+  if (!user) return null
+  const passwordHash = crypto.createHash('sha256').update(password).digest('hex')
+  if (user.passwordHash !== passwordHash) return null
+  return { name: user.name, department: user.department }
+}

--- a/taintedpaint/types.ts
+++ b/taintedpaint/types.ts
@@ -53,3 +53,9 @@ export interface BoardSummaryData {
   tasks: Record<string, TaskSummary>;
   columns: Column[];
 }
+
+export interface User {
+  name: string;
+  department: string;
+  passwordHash: string;
+}


### PR DESCRIPTION
## Summary
- require login before accessing kanban
- add signup/login pages and API routes with department selection
- add account icon and remove 总揽 link

## Testing
- `cd taintedpaint && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894c593e304832f926c71ef717d7aeb