### PR TITLE
Allow manual order IDs in sheet column

### DIFF
--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -247,12 +247,6 @@ export default function KanbanBoard() {
     }
   }, [highlightTaskId])
 
-  const getNextYnmxId = useCallback(() => {
-    const today = new Date().toISOString().slice(0, 10)
-    const random = Math.floor(1000 + Math.random() * 9000)
-    return `YNMX-${today}-${random}`
-  }, [])
-
   const getTaskDisplayName = (task: TaskSummary) => {
     if (viewMode === 'production') {
       return task.ynmxId || `${task.customerName} - ${task.representative}`
@@ -555,9 +549,6 @@ export default function KanbanBoard() {
         ...(existingTask?.history || []),
         { user: userName, timestamp: moveTime, description: `移动到${columns.find(c => c.id === targetColumnId)?.title || ''}` },
       ],
-    }
-    if (targetColumnId === 'sheet' && !draggedTask.ynmxId) {
-      updatedTask = { ...updatedTask, ynmxId: getNextYnmxId() }
     }
     if (targetColumnId === 'ship') {
       try {

--- a/taintedpaint/types.ts
+++ b/taintedpaint/types.ts
@@ -13,7 +13,7 @@ export interface Task {
   notes: string;
   taskFolderPath?: string;
   files?: string[];
-  ynmxId?: string; // ID assigned when moving to approval
+  ynmxId?: string; // Order ID provided by users
   deliveryNoteGenerated?: boolean;
   /** Whether this task is waiting for acceptance in the target column */
   awaitingAcceptance?: boolean;


### PR DESCRIPTION
## Summary
- Remove automatic YNMX ID generation when moving tasks to the 制单 column
- Update task type comments to note that order IDs are user-provided

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894daeff558832fb17bae1ae172f553