### PR TITLE
Apply login-based board restrictions and simplify Electron wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,8 @@ This repository contains two parts:
 - `taintedpaint` – the Next.js web app.
 - `blackpaint` – the Electron wrapper named **Estara**.
 
-Two Electron builds can be produced:
-
-1. **Administrator build** – full access.
-2. **Production build** – locked to production view with some UI disabled.
+The Electron app now loads the web interface directly; user logins determine
+whether the full or restricted view is shown.
 
 ## Web App
 
@@ -25,27 +23,10 @@ By default the web app runs on `http://192.168.5.107:3001`. Set `NEXT_PUBLIC_APP
 ```
 cd blackpaint
 npm install
-```
-
-### Administrator version
-
-```
 npm run make
 ```
 
-### Production version
-
-```
-npm run make:restricted
-```
-
-The production build adds `?restricted=1` to the web URL so the web interface automatically hides the Business switcher and Holistic view.
-
-### Why it mattered
-
-Initially the `make:restricted` script set the `RESTRICTED` environment variable only while running the build. Because the packaged application started without that variable present, `process.env.RESTRICTED` evaluated to `undefined`, so the restricted mode was never enabled. Webpack now copies the value of `RESTRICTED` into the bundled code at build time, ensuring the production package always loads with the proper query parameter.
-
-The packaged apps can be found in `blackpaint/out` after running the commands.
+The packaged apps can be found in `blackpaint/out` after running the command.
 
 ## Architecture & Workflow
 

--- a/blackpaint/README.md
+++ b/blackpaint/README.md
@@ -1,17 +1,8 @@
 # Estara (Blackpaint)
 
 This folder contains the Electron wrapper for the `taintedpaint` web
-application. Two distributable versions exist:
-
-- **Administrator** – no restrictions, loads the web app directly.
-- **Production** – restricted view. The Electron window loads the web URL with
-  `?restricted=1` appended. Inside `taintedpaint` this query param disables the
-  商务 tab so production workers only see the 生产 section.
-
-The build script `npm run make:restricted` sets the `RESTRICTED` environment
-variable and Webpack's `EnvironmentPlugin` embeds its value into the compiled
-code. The main process checks this value and appends the query parameter when
-creating the browser window.
+application. The app now always loads the same web interface and relies on user
+logins to determine whether the full or restricted view is shown.
 
 ### SMB share
 
@@ -27,11 +18,10 @@ SMB_CLIENT_ROOT=\\YOUR-SERVER\CrystalData npm run make
 You no longer need to set this variable when launching the installed
 application; the compiled value will be used automatically.
 
-Run one of these inside this folder after installing dependencies:
+Run this inside this folder after installing dependencies:
 
 ```bash
-npm run make        # Administrator build
-npm run make:restricted  # Production build
+npm run make
 ```
 
 The generated installers will be in `out/`.

--- a/blackpaint/package.json
+++ b/blackpaint/package.json
@@ -8,7 +8,6 @@
     "start": "electron-forge start",
     "package": "electron-forge package",
     "make": "electron-forge make",
-    "make:restricted": "cross-env RESTRICTED=1 electron-forge make",
     "publish": "electron-forge publish",
     "lint": "eslint --ext .ts,.tsx ."
   },

--- a/blackpaint/src/index.ts
+++ b/blackpaint/src/index.ts
@@ -40,8 +40,7 @@ const createWindow = (): void => {
 
   // and load the index.html of the app.
   const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://192.168.5.107:3001';
-  const appUrl = process.env.RESTRICTED ? `${baseUrl}?restricted=1` : baseUrl;
-  mainWindow.loadURL(appUrl);
+  mainWindow.loadURL(baseUrl);
 
   // Open the DevTools automatically when running in development.
   if (!app.isPackaged) {

--- a/blackpaint/webpack.main.config.ts
+++ b/blackpaint/webpack.main.config.ts
@@ -17,7 +17,6 @@ export const mainConfig: Configuration = {
   plugins: [
     ...plugins,
     new webpack.EnvironmentPlugin({
-      RESTRICTED: '',
       SMB_CLIENT_ROOT: process.env.SMB_CLIENT_ROOT || '\\FWQ88\\Estara',
     }),
   ],

--- a/blackpaint/webpack.renderer.config.ts
+++ b/blackpaint/webpack.renderer.config.ts
@@ -16,7 +16,6 @@ export const rendererConfig: Configuration = {
   plugins: [
     ...plugins,
     new webpack.EnvironmentPlugin({
-      RESTRICTED: '',
       SMB_CLIENT_ROOT: process.env.SMB_CLIENT_ROOT || '\\FWQ88\\Estara',
     }),
   ],

--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -4,7 +4,7 @@ import type React from "react"
 import type { Task, TaskSummary, Column, BoardData, BoardSummaryData } from "@/types"
 import { useState, useEffect, useCallback, useMemo, useRef } from "react"
 import CreateJobForm from "@/components/CreateJobForm"
-import { Archive, Lock, RotateCw, Check, Plus, Clock, Search, X } from "lucide-react"
+import { Archive, RotateCw, Check, Plus, Clock, Search, X } from "lucide-react"
 import { baseColumns, START_COLUMN_ID, ARCHIVE_COLUMN_ID } from "@/lib/baseColumns"
 import TaskModal from "@/components/TaskModal"
 import AccountButton from "@/components/AccountButton"
@@ -42,15 +42,16 @@ import { formatTimeAgo } from "@/lib/utils"
 )
 
 export default function KanbanBoard() {
-  const restricted = typeof window !== 'undefined' && new URLSearchParams(window.location.search).get('restricted') === '1'
+  const stored = typeof window !== "undefined" ? localStorage.getItem("user") : null
+  const department = stored ? JSON.parse(stored).department : ""
+  const viewMode: 'business' | 'production' = ['商务', '检验'].includes(department)
+    ? 'business'
+    : 'production'
 
   const [tasks, setTasks] = useState<Record<string, TaskSummary & Partial<Task>>>(
     {},
   )
   const [columns, setColumns] = useState<Column[]>(baseColumns)
-  const [viewMode, setViewMode] = useState<'business' | 'production'>(
-    restricted ? 'production' : 'business',
-  )
   const [draggedTask, setDraggedTask] = useState<(TaskSummary & Partial<Task>) | null>(null)
   const [dragOverColumn, setDragOverColumn] = useState<string | null>(null)
   const [dropIndicatorIndex, setDropIndicatorIndex] = useState<number | null>(null)
@@ -693,32 +694,6 @@ export default function KanbanBoard() {
               <RotateCw className="w-4 h-4" />
             </button>
 
-            <div className="w-px h-5 bg-gray-200 mx-2" />
-            
-            <div className="flex items-center bg-white/60 backdrop-blur rounded-xl p-0.5 border apple-border-light">
-              <button
-                onClick={() => !restricted && setViewMode('business')}
-                className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-all ${
-                  viewMode === 'business' 
-                    ? 'bg-white text-gray-900 apple-shadow' 
-                    : 'text-gray-600 hover:text-gray-900'
-                } ${restricted ? 'cursor-not-allowed opacity-50' : ''}`}
-                disabled={restricted}
-              >
-                {restricted && <Lock className="inline-block w-3 h-3 mr-1" />}
-                商务
-              </button>
-              <button
-                onClick={() => setViewMode('production')}
-                className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-all ${
-                  viewMode === 'production' 
-                    ? 'bg-white text-gray-900 apple-shadow' 
-                    : 'text-gray-600 hover:text-gray-900'
-                }`}
-              >
-                生产
-              </button>
-            </div>
           </div>
 
           <div className="flex items-center gap-3">
@@ -741,7 +716,7 @@ export default function KanbanBoard() {
       </header>
       
       <div className="relative flex-1 flex overflow-hidden">
-        {/* Board toolbar: refresh + view toggle + quick search */}
+        {/* Board toolbar: refresh + quick search */}
         <div className="absolute top-0 left-0 right-0 px-6 pt-4 z-20">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
@@ -753,18 +728,6 @@ export default function KanbanBoard() {
               >
                 <RotateCw className="w-4 h-4" />
               </button>
-              <div className="w-px h-5 bg-gray-200" />
-              <div className="flex items-center bg-white/60 backdrop-blur rounded-xl p-0.5 border apple-border-light">
-                <button
-                  onClick={() => !restricted && setViewMode('business')}
-                  className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-all ${viewMode === 'business' ? 'bg-white text-gray-900 apple-shadow' : 'text-gray-600 hover:text-gray-900'} ${restricted ? 'cursor-not-allowed opacity-50' : ''}`}
-                  disabled={restricted}
-                >商务</button>
-                <button
-                  onClick={() => setViewMode('production')}
-                  className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-all ${viewMode === 'production' ? 'bg-white text-gray-900 apple-shadow' : 'text-gray-600 hover:text-gray-900'}`}
-                >生产</button>
-              </div>
             </div>
             <div className="flex items-center gap-2">
               <div className="relative hidden sm:block">


### PR DESCRIPTION
## Summary
- Remove manual 商务/生产 toggle; board view now derives from the logged-in user's department.
- Always load the web app directly in the Electron wrapper and drop the restricted build path.
- Update docs to describe login-controlled views and single Electron build.

## Testing
- `npm test` (taintedpaint)
- `npm test` (blackpaint; fails: Missing script)
- `npm test` (root; fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_6895674047a8832f9c561ebad3426dd7