### PR TITLE
Add createdAt field to Task interfaces

### DIFF
--- a/taintedpaint/types.ts
+++ b/taintedpaint/types.ts
@@ -17,6 +17,8 @@ export interface Task {
   deliveryNoteGenerated?: boolean;
   /** Whether this task is waiting for acceptance in the target column */
   awaitingAcceptance?: boolean;
+  /** ISO timestamp when the task was created */
+  createdAt?: string;
   /** ISO timestamp of the last modification */
   updatedAt?: string;
   /** Name of the user who made the last modification */
@@ -44,6 +46,8 @@ export interface TaskSummary {
   ynmxId?: string;
   deliveryNoteGenerated?: boolean;
   awaitingAcceptance?: boolean;
+  /** ISO timestamp when the task was created */
+  createdAt?: string;
   /** ISO timestamp of the last modification */
   updatedAt?: string;
   /** Name of the user who made the last modification */


### PR DESCRIPTION
## Summary
- include optional `createdAt` timestamp in `Task` and `TaskSummary` interfaces
- allow components referencing `createdAt` to type-check

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68957fc2fdb4832fa2f94136af227a8f