### PR TITLE
Fix horizontal scrollbar visibility on Kanban board

### DIFF
--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -773,7 +773,7 @@ export default function KanbanBoard() {
       {/* BOARD SCROLLER */}
       <div
         ref={scrollContainerRef}
-        className="flex-1 flex gap-4 overflow-x-auto overflow-y-hidden p-6 [scrollbar-gutter:stable] scroll-smooth overscroll-x-contain"
+        className="flex-1 min-h-0 flex gap-4 overflow-x-auto overflow-y-hidden p-6 [scrollbar-gutter:stable] scroll-smooth overscroll-x-contain"
       >
         {handoffToast && (
           <div className="fixed left-1/2 -translate-x-1/2 top-16 z-50">


### PR DESCRIPTION
## Summary
- ensure board container can shrink within viewport so horizontal scrollbar stays visible

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68959939e470832fb2862deb5618c6cd