### PR TITLE
Ensure bottom scrollbar stays visible

### DIFF
--- a/taintedpaint/app/holistic/page.tsx
+++ b/taintedpaint/app/holistic/page.tsx
@@ -165,7 +165,7 @@ export default function ArchivePage() {
   // ⑥ JSX 渲染 --------------------------------------------------------------------
   return (
     <div
-      className="min-h-screen bg-white font-sans text-gray-900"
+      className="min-h-full bg-white font-sans text-gray-900"
       style={{ fontFamily: '"Noto Sans SC","PingFang SC","Hiragino Sans GB","Microsoft YaHei",sans-serif' }}
     >
       <div className="max-w-6xl mx-auto px-6 py-8">

--- a/taintedpaint/app/login/page.tsx
+++ b/taintedpaint/app/login/page.tsx
@@ -34,7 +34,7 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+    <div className="min-h-full flex items-center justify-center bg-gray-50">
       <form onSubmit={handleSubmit} className="bg-white p-6 rounded shadow w-full max-w-sm space-y-4">
         <h1 className="text-xl font-semibold text-center">登录</h1>
         {error && <p className="text-red-500 text-sm">{error}</p>}

--- a/taintedpaint/app/signup/page.tsx
+++ b/taintedpaint/app/signup/page.tsx
@@ -37,7 +37,7 @@ export default function SignupPage() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+    <div className="min-h-full flex items-center justify-center bg-gray-50">
       <form onSubmit={handleSubmit} className="bg-white p-6 rounded shadow w-full max-w-sm space-y-4">
         <h1 className="text-xl font-semibold text-center">注册</h1>
         {error && <p className="text-red-500 text-sm">{error}</p>}

--- a/taintedpaint/components/AppShell.tsx
+++ b/taintedpaint/components/AppShell.tsx
@@ -36,7 +36,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
   }
 
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="h-screen flex flex-col">
       <header className="apple-glass apple-shadow sticky top-0 z-40 border-b border-transparent">
         <div className="w-full px-6 h-14 flex items-center justify-between">
           <div className="flex items-center gap-3">

--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -769,7 +769,7 @@ export default function KanbanBoard() {
      - Column headers: sticky + bg + z-index + gradient mask
      ───────────────────────────────────────────────────────────────────────── */
   return (
-    <div className="h-screen w-full flex flex-col text-gray-900 overflow-hidden bg-[#F4F5F7]">
+    <div className="h-full w-full flex flex-col text-gray-900 overflow-hidden bg-[#F4F5F7]">
       {/* BOARD SCROLLER */}
       <div
         ref={scrollContainerRef}


### PR DESCRIPTION
## Summary
- avoid off-screen horizontal scrollbar by sizing AppShell to viewport height
- size board and auth pages to parent height so horizontal scrolling remains at bottom

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68959b5f4438832fb4d79f8e05fa632f