### PR TITLE
fix: align BottomHScroll ref types

### DIFF
--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -151,7 +151,7 @@ function BottomHScroll({
   sidePadding = 24,        // line up with board p-6 (24px)
   bottomOffset = 12,       // float slightly above window bottom
 }: {
-  targetRef: React.RefObject<HTMLElement>;
+  targetRef: React.RefObject<HTMLDivElement | null>;
   minThumbPx?: number;
   sidePadding?: number;
   bottomOffset?: number;


### PR DESCRIPTION
## Summary
- accept HTMLDivElement refs in BottomHScroll to fix type mismatch

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895a10481dc832f9c4d2e4841c4c651