### PR TITLE
Limit layout width for readability

### DIFF
--- a/taintedpaint/components/AppShell.tsx
+++ b/taintedpaint/components/AppShell.tsx
@@ -38,7 +38,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
   return (
     <div className="min-h-screen flex flex-col">
       <header className="apple-glass apple-shadow sticky top-0 z-40 border-b border-transparent">
-        <div className="w-full px-6 h-14 flex items-center justify-between">
+        <div className="w-full max-w-screen-xl px-6 h-14 flex items-center justify-between mx-auto">
           <div className="flex items-center gap-3">
             <Link href="/" className="text-[15px] font-semibold tracking-tight text-gray-900">Estara</Link>
             {isBoard && (
@@ -79,7 +79,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
         </div>
       </header>
 
-      <main className="flex-1">
+      <main className="flex-1 w-full max-w-screen-xl mx-auto">
         {children}
       </main>
 

--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -674,7 +674,7 @@ export default function KanbanBoard() {
      - Add pb-16 to avoid overlap with the fixed mini-map.
      ───────────────────────────────────────────────────────────────────────── */
   return (
-    <div className="h-screen w-full flex flex-col text-gray-900 overflow-hidden bg-[#F4F5F7] pb-16">
+    <div className="h-screen w-full max-w-screen-xl mx-auto flex flex-col text-gray-900 overflow-hidden bg-[#F4F5F7] pb-16">
       {/* Toast (handoff feedback) */}
       {handoffToast && (
         <div className="fixed left-1/2 -translate-x-1/2 top-16 z-50">


### PR DESCRIPTION
## Summary
- Constrain header and main containers to a maximum width for centered layout
- Limit Kanban board wrapper width to match header and avoid overly wide columns

## Testing
- `cd taintedpaint && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895bbbd6440832fb31d115c3e386e3a