### PR TITLE
Fix drag handler types in Kanban column

### DIFF
--- a/taintedpaint/components/KanbanColumn.tsx
+++ b/taintedpaint/components/KanbanColumn.tsx
@@ -18,11 +18,11 @@ interface KanbanColumnProps {
   highlightTaskId: string | null;
   handleTaskClick: (task: Task, e: React.MouseEvent) => void;
   handleDragStart: (e: React.DragEvent, task: Task) => void;
-  handleDragEnd: (e: React.DragEvent) => void;
+  handleDragEnd: () => void;
   handleDragOverTask: (e: React.DragEvent, index: number, columnId: string) => void;
   handleDragOver: (e: React.DragEvent) => void;
   handleDragEnterColumn: (columnId: string) => void;
-  handleDragLeaveColumn: () => void;
+  handleDragLeaveColumn: (e: React.DragEvent) => void;
   handleDrop: (e: React.DragEvent, columnId: string, dropIndex?: number) => void;
   dragOverColumn: string | null;
   dropIndicatorIndex: number | null;


### PR DESCRIPTION
## Summary
- align KanbanColumn drag handler types with TaskCard props
- ensure drag leave handler accepts event while drag end ignores it

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895bd6acf70832fa95f0309b155f9e3