### PR TITLE
feat: use amber for overdue tasks

### DIFF
--- a/taintedpaint/components/TaskCard.tsx
+++ b/taintedpaint/components/TaskCard.tsx
@@ -59,7 +59,7 @@ export default function TaskCard({
         <span
           className={[
             "px-2 py-0.5 rounded-full text-[11px] font-medium flex items-center gap-1",
-            overdue ? "bg-red-100 text-[#D9534F]" : "bg-gray-100 text-gray-700",
+            overdue ? "bg-[#F59E0B]/10 text-[#F59E0B]" : "bg-gray-100 text-gray-700",
           ].join(" ")}
         >
           <CalendarDays className="w-3 h-3" />


### PR DESCRIPTION
## Summary
- use amber #F59E0B highlight for overdue tasks instead of red

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6895cf0811d8832f8eec8e720e2dfc40