### PR TITLE
Ensure Kanban column headers remain visible

### DIFF
--- a/taintedpaint/components/AppShell.tsx
+++ b/taintedpaint/components/AppShell.tsx
@@ -36,7 +36,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
   }
 
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="h-screen flex flex-col">
       <header className="apple-glass apple-shadow sticky top-0 z-40 border-b border-transparent">
         <div className="w-full px-6 h-14 flex items-center justify-between">
           <div className="flex items-center gap-3">

--- a/taintedpaint/components/KanbanColumn.tsx
+++ b/taintedpaint/components/KanbanColumn.tsx
@@ -86,10 +86,10 @@ export default function KanbanColumn({
       onDragEnter={() => handleDragEnterColumn(column.id)}
       onDragLeave={handleDragLeaveColumn}
       onDrop={(e) => handleDrop(e, column.id, dropIndicatorIndex ?? undefined)}
-      className="relative flex-shrink-0 w-80 flex flex-col rounded-md border border-gray-200 bg-gray-50 overflow-hidden min-h-0"
+      className="relative flex-shrink-0 w-80 h-full flex flex-col rounded-md border border-gray-200 bg-gray-50 overflow-hidden min-h-0"
     >
       {/* Column Header */}
-      <div className="relative z-10 bg-gray-50 px-3 py-2 border-b border-gray-200 flex items-center justify-between">
+      <div className="sticky top-0 z-10 bg-gray-50 px-3 py-2 border-b border-gray-200 flex items-center justify-between">
         <div className="flex items-center gap-2">
           {isArchive && <Archive className="w-4 h-4 text-gray-400" />}
           <h2 className="text-[11px] font-semibold text-gray-700 uppercase tracking-wide">


### PR DESCRIPTION
## Summary
- Keep app shell constrained to viewport height
- Make Kanban column headers sticky and columns full height

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6895d7fab868832f85feeedf6a87e6ff