### PR TITLE
Hide customer info in restricted add task view

### DIFF
--- a/taintedpaint/components/KanbanColumn.tsx
+++ b/taintedpaint/components/KanbanColumn.tsx
@@ -156,7 +156,9 @@ export default function KanbanColumn({
                   .filter((t) => t && (t as any).id)
                   .filter((t) => {
                     if (q === "") return true;
-                    const text = `${t.customerName} ${t.representative} ${t.ynmxId || ""} ${t.notes || ""}`.toLowerCase();
+                    const text = isRestricted
+                      ? `${(t as any).ynmxId || ""}`.toLowerCase()
+                      : `${t.customerName} ${t.representative} ${t.ynmxId || ""} ${t.notes || ""}`.toLowerCase();
                     return text.includes(q);
                   })
                   .slice(0, 50);
@@ -173,15 +175,23 @@ export default function KanbanColumn({
                     >
                       <div className="min-w-0">
                         <div className="text-sm font-medium text-gray-900 truncate">
-                          {(t as any).customerName}{" "}
-                          <span className="text-gray-500">· {(t as any).representative}</span>
-                        </div>
-                        <div className="flex items-center gap-2 text-xs text-gray-500">
-                          {(t as any).ynmxId && <span className="truncate">{(t as any).ynmxId}</span>}
-                          {col && (
-                            <span className="px-1.5 py-0.5 rounded-[2px] bg-gray-100 border border-gray-200">{col.title}</span>
+                          {isRestricted ? (
+                            getTaskDisplayName(t as any)
+                          ) : (
+                            <>
+                              {(t as any).customerName}{" "}
+                              <span className="text-gray-500">· {(t as any).representative}</span>
+                            </>
                           )}
                         </div>
+                        {!isRestricted && (
+                          <div className="flex items-center gap-2 text-xs text-gray-500">
+                            {(t as any).ynmxId && <span className="truncate">{(t as any).ynmxId}</span>}
+                            {col && (
+                              <span className="px-1.5 py-0.5 rounded-[2px] bg-gray-100 border border-gray-200">{col.title}</span>
+                            )}
+                          </div>
+                        )}
                       </div>
                     </button>
                   );
@@ -232,8 +242,8 @@ export default function KanbanColumn({
                       <h3 className="text-sm font-medium text-gray-900 truncate">
                         {getTaskDisplayName(task)}
                       </h3>
-                      <p className="text-xs text-gray-600">{task.representative}</p>
-                    </div>
+                      {!isRestricted && <p className="text-xs text-gray-600">{task.representative}</p>}
+                      </div>
                     <div className="flex gap-1 ml-2 flex-shrink-0">
                       <button
                         className="p-1 rounded-[2px] bg-green-100 text-green-700 hover:bg-green-200 transition-colors"

--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -250,6 +250,9 @@ export default function KanbanBoard() {
   // Display name differs by viewMode
   const getTaskDisplayName = (task: TaskSummary) => {
     if (viewMode === "production") {
+      if (isRestricted) {
+        return task.ynmxId || "—";
+      }
       return task.ynmxId || `${task.customerName} - ${task.representative}`;
     }
     return `${task.customerName} - ${task.representative}`;


### PR DESCRIPTION
## Summary
- Respect restricted mode when deriving task display names
- Limit add-task picker search/results to YNMX IDs for restricted users
- Hide representative names in pending tasks for restricted users

## Testing
- `npm test` *(fails: Error: no test specified)*
- `cd taintedpaint && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896c7eba608832fbd70e9152f8d6c92