### PR TITLE
Restrict manufacturing task view

### DIFF
--- a/taintedpaint/components/KanbanColumn.tsx
+++ b/taintedpaint/components/KanbanColumn.tsx
@@ -158,7 +158,9 @@ export default function KanbanColumn({
                   .filter((t) => !column.taskIds.includes((t as any).id))
                   .filter((t) => {
                     if (q === "") return true;
-                    const text = `${t.customerName} ${t.representative} ${t.ynmxId || ""} ${t.notes || ""}`.toLowerCase();
+                    const text = isRestricted
+                      ? `${t.ynmxId || ""}`.toLowerCase()
+                      : `${t.customerName} ${t.representative} ${t.ynmxId || ""} ${t.notes || ""}`.toLowerCase();
                     return text.includes(q);
                   })
                   .slice(0, 50);
@@ -174,16 +176,24 @@ export default function KanbanColumn({
                       className="w-full text-left px-3 py-2 hover:bg-gray-50 rounded-[2px] transition-colors"
                     >
                       <div className="min-w-0">
-                        <div className="text-sm font-medium text-gray-900 truncate">
-                          {(t as any).customerName}{" "}
-                          <span className="text-gray-500">· {(t as any).representative}</span>
-                        </div>
-                        <div className="flex items-center gap-2 text-xs text-gray-500">
-                          {(t as any).ynmxId && <span className="truncate">{(t as any).ynmxId}</span>}
-                          {col && (
-                            <span className="px-1.5 py-0.5 rounded-[2px] bg-gray-100 border border-gray-200">{col.title}</span>
-                          )}
-                        </div>
+                        {isRestricted ? (
+                          <div className="text-sm font-medium text-gray-900 truncate">
+                            {(t as any).ynmxId || "—"}
+                          </div>
+                        ) : (
+                          <>
+                            <div className="text-sm font-medium text-gray-900 truncate">
+                              {(t as any).customerName}{" "}
+                              <span className="text-gray-500">· {(t as any).representative}</span>
+                            </div>
+                            <div className="flex items-center gap-2 text-xs text-gray-500">
+                              {(t as any).ynmxId && <span className="truncate">{(t as any).ynmxId}</span>}
+                              {col && (
+                                <span className="px-1.5 py-0.5 rounded-[2px] bg-gray-100 border border-gray-200">{col.title}</span>
+                              )}
+                            </div>
+                          </>
+                        )}
                       </div>
                     </button>
                   );
@@ -232,7 +242,9 @@ export default function KanbanColumn({
                       <h3 className="text-sm font-medium text-gray-900 truncate">
                         {getTaskDisplayName(task)}
                       </h3>
-                      <p className="text-xs text-gray-600">{task.representative}</p>
+                      {!isRestricted && (
+                        <p className="text-xs text-gray-600">{task.representative}</p>
+                      )}
                     </div>
                     <div className="flex gap-1 ml-2 flex-shrink-0">
                       <button

--- a/taintedpaint/components/TaskCard.tsx
+++ b/taintedpaint/components/TaskCard.tsx
@@ -55,7 +55,7 @@ export default function TaskCard({
       <h3 className="truncate text-[13px] leading-snug font-medium text-gray-900">{titleNode}</h3>
 
       <div className="mt-2 flex flex-wrap gap-1">
-        {task.representative && (
+        {task.representative && !isRestricted && (
           <span className="px-2 py-0.5 rounded-[2px] bg-gray-100 text-gray-700 text-[11px] font-medium">
             {searchRender(task.representative)}
           </span>
@@ -75,7 +75,7 @@ export default function TaskCard({
         </span>
       </div>
 
-      {task.notes && (
+      {task.notes && !isRestricted && (
         <p className="mt-2 truncate text-[12px] leading-snug text-gray-500">{searchRender(task.notes)}</p>
       )}
 

--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -250,6 +250,9 @@ export default function KanbanBoard() {
 
   // Display name differs by viewMode
   const getTaskDisplayName = (task: TaskSummary) => {
+    if (isRestricted) {
+      return task.ynmxId || "—";
+    }
     if (viewMode === "production") {
       return task.ynmxId || `${task.customerName} - ${task.representative}`;
     }


### PR DESCRIPTION
## Summary
- Hide customer details from Add Task picker and pending tasks when manufacturing users have restricted access
- Conceal representative and notes on task cards for restricted viewers
- Fall back to YNMX ID for task display names when restricted

## Testing
- `npm test` (fails: no test specified)
- `cd taintedpaint && npm test`
- `cd taintedpaint && npm run lint` (fails: requires interactive config)


------
https://chatgpt.com/codex/tasks/task_e_6896cbaf9678832fa1d536798a9509ea