### PR TITLE
Allow creating blank tasks

### DIFF
--- a/taintedpaint/app/api/jobs/route.ts
+++ b/taintedpaint/app/api/jobs/route.ts
@@ -112,30 +112,16 @@ export async function POST(req: NextRequest) {
       folderName = '',
       updatedBy = '',
     } = fields;
-
-    if (
-      tempFiles.length === 0 ||
-      !customerName ||
-      !representative ||
-      !inquiryDate ||
-      !folderName
-    ) {
-      return NextResponse.json(
-        { error: 'Missing required fields or folder' },
-        { status: 400 }
-      );
-    }
-
     const taskId = Date.now().toString();
     const taskDirectoryPath = path.join(TASKS_STORAGE_DIR, taskId);
     await fs.mkdir(taskDirectoryPath, { recursive: true });
 
-    const rootPrefix = folderName.replace(/[/\\]+$/, '') + '/';
+    const rootPrefix = folderName ? folderName.replace(/[/\\]+$/, '') + '/' : '';
 
     for (let i = 0; i < tempFiles.length; i++) {
       const rawPath = filePaths[i];
       if (!rawPath) continue;
-      const relativePath = rawPath.startsWith(rootPrefix)
+      const relativePath = rootPrefix && rawPath.startsWith(rootPrefix)
         ? rawPath.slice(rootPrefix.length)
         : rawPath;
       const safeRelativePath = path
@@ -151,16 +137,16 @@ export async function POST(req: NextRequest) {
     const newTask: Task = {
       id: taskId,
       columnId: START_COLUMN_ID,
-      customerName: customerName.trim(),
-      representative: representative.trim(),
-      inquiryDate: inquiryDate.trim(),
+      customerName: customerName.trim() || undefined,
+      representative: representative.trim() || undefined,
+      inquiryDate: inquiryDate.trim() || undefined,
       deliveryDate: deliveryDate.trim() || undefined,
-      notes: notes.trim(),
+      notes: notes.trim() || undefined,
       ynmxId: ynmxId.trim() || undefined,
       // Store the relative path inside the SMB share so clients can resolve it
       // using their own mounted location.
       taskFolderPath: `${TASKS_DIR_NAME}/${taskId}`,
-      files: [folderName],
+      files: folderName ? [folderName] : [],
       deliveryNoteGenerated: false,
       awaitingAcceptance: false,
       updatedAt: now,

--- a/taintedpaint/components/CreateJobForm.tsx
+++ b/taintedpaint/components/CreateJobForm.tsx
@@ -80,31 +80,24 @@ export default function CreateJobForm({ onJobCreated }: CreateJobFormProps) {
   }
 
   const handleCreateJob = async () => {
-    if (
-      !selectedFiles ||
-      selectedFiles.length === 0 ||
-      !customerName.trim() ||
-      !representative.trim() ||
-      !inquiryDate.trim()
-    )
-      return
-
     setIsCreating(true)
     try {
       const formData = new FormData()
-      
-      for (const file of Array.from(selectedFiles)) {
-        formData.append("files", file)
-        formData.append("filePaths", (file as any).webkitRelativePath)
+
+      if (selectedFiles) {
+        for (const file of Array.from(selectedFiles)) {
+          formData.append("files", file)
+          formData.append("filePaths", (file as any).webkitRelativePath)
+        }
+        formData.append("folderName", getFolderName())
       }
-      
+
       formData.append("customerName", customerName.trim())
       formData.append("representative", representative.trim())
       formData.append("inquiryDate", inquiryDate.trim())
       formData.append("deliveryDate", deliveryDate.trim())
       formData.append("ynmxId", ynmxId.trim())
       formData.append("notes", notes.trim())
-      formData.append("folderName", getFolderName())
       formData.append("updatedBy", userName)
 
       const res = await fetch("/api/jobs", {
@@ -243,14 +236,7 @@ export default function CreateJobForm({ onJobCreated }: CreateJobFormProps) {
         <Button
           onClick={handleCreateJob}
           className="w-full h-9 text-white text-sm font-medium rounded-[2px] transition-all disabled:opacity-50"
-          disabled={
-            !selectedFiles ||
-            selectedFiles.length === 0 ||
-            !customerName ||
-            !representative ||
-            !inquiryDate ||
-            isCreating
-          }
+          disabled={isCreating}
         >
           {isCreating ? (
             <Loader2 className="w-4 h-4 animate-spin" />

--- a/taintedpaint/components/NewTaskDialog.tsx
+++ b/taintedpaint/components/NewTaskDialog.tsx
@@ -42,22 +42,20 @@ export default function NewTaskDialog({
   }
 
   const handleCreate = async () => {
-    if (!customerName.trim() || !representative.trim() || !inquiryDate.trim()) return
     setIsCreating(true)
     try {
+      const formData = new FormData()
+      formData.append("customerName", customerName.trim())
+      formData.append("representative", representative.trim())
+      formData.append("inquiryDate", inquiryDate.trim())
+      formData.append("deliveryDate", deliveryDate.trim())
+      formData.append("ynmxId", ynmxId.trim())
+      formData.append("notes", notes.trim())
+      formData.append("updatedBy", userName)
+
       const res = await fetch("/api/jobs", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          customerName: customerName.trim(),
-          representative: representative.trim(),
-          inquiryDate: inquiryDate.trim(),
-          deliveryDate: deliveryDate.trim(),
-          ynmxId: ynmxId.trim(),
-          notes: notes.trim(),
-          updatedBy: userName,
-          noFiles: true,
-        })
+        body: formData,
       })
       if (!res.ok) throw new Error("服务端错误")
       const task: Task = await res.json()
@@ -95,7 +93,7 @@ export default function NewTaskDialog({
         </div>
         <DialogFooter>
           <Button variant="outline" onClick={() => onOpenChange(false)}>取消</Button>
-          <Button onClick={handleCreate} disabled={!customerName || !representative || !inquiryDate || isCreating}>{isCreating ? '创建中...' : '创建'}</Button>
+          <Button onClick={handleCreate} disabled={isCreating}>{isCreating ? '创建中...' : '创建'}</Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/taintedpaint/types.ts
+++ b/taintedpaint/types.ts
@@ -5,12 +5,12 @@ export interface Task {
   columnId: string; // <-- NEW
   /** Previous column when awaiting acceptance */
   previousColumnId?: string;
-  customerName: string;
-  representative: string;
-  inquiryDate: string;
+  customerName?: string;
+  representative?: string;
+  inquiryDate?: string;
   /** Required delivery date, editable in the Kanban drawer */
   deliveryDate?: string;
-  notes: string;
+  notes?: string;
   taskFolderPath?: string;
   files?: string[];
   ynmxId?: string; // Order ID provided by users
@@ -38,11 +38,11 @@ export interface TaskSummary {
   id: string;
   columnId: string;
   previousColumnId?: string;
-  customerName: string;
-  representative: string;
-  inquiryDate: string;
+  customerName?: string;
+  representative?: string;
+  inquiryDate?: string;
   deliveryDate?: string;
-  notes: string;
+  notes?: string;
   ynmxId?: string;
   deliveryNoteGenerated?: boolean;
   awaitingAcceptance?: boolean;


### PR DESCRIPTION
## Summary
- Allow creating tasks without uploading files or filling required fields
- Mark task metadata as optional and update forms to no longer enforce inputs
- Remove server-side checks for missing task fields

## Testing
- `cd taintedpaint && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896e682ceb0832f898f5641a962de38