### PR TITLE
Allow creating tasks with blank fields

### DIFF
--- a/taintedpaint/app/api/search/route.ts
+++ b/taintedpaint/app/api/search/route.ts
@@ -16,7 +16,7 @@ export async function GET(req: NextRequest) {
     const results = Object.values(data.tasks as Record<string, Task>)
       .filter((task) => {
         if (task.columnId === 'archive' || task.columnId === 'archive2') return false;
-        const text = `${task.customerName} ${task.representative} ${task.ynmxId ?? ''} ${task.notes ?? ''}`.toLowerCase();
+        const text = `${task.customerName ?? ''} ${task.representative ?? ''} ${task.ynmxId ?? ''} ${task.notes ?? ''}`.toLowerCase();
         return text.includes(query);
       })
       .slice(0, 3)

--- a/taintedpaint/types.ts
+++ b/taintedpaint/types.ts
@@ -5,12 +5,12 @@ export interface Task {
   columnId: string; // <-- NEW
   /** Previous column when awaiting acceptance */
   previousColumnId?: string;
-  customerName: string;
-  representative: string;
-  inquiryDate: string;
+  customerName?: string;
+  representative?: string;
+  inquiryDate?: string;
   /** Required delivery date, editable in the Kanban drawer */
   deliveryDate?: string;
-  notes: string;
+  notes?: string;
   taskFolderPath?: string;
   files?: string[];
   ynmxId?: string; // Order ID provided by users
@@ -38,11 +38,11 @@ export interface TaskSummary {
   id: string;
   columnId: string;
   previousColumnId?: string;
-  customerName: string;
-  representative: string;
-  inquiryDate: string;
+  customerName?: string;
+  representative?: string;
+  inquiryDate?: string;
   deliveryDate?: string;
-  notes: string;
+  notes?: string;
   ynmxId?: string;
   deliveryNoteGenerated?: boolean;
   awaitingAcceptance?: boolean;


### PR DESCRIPTION
## Summary
- Make all task properties optional in shared types
- Permit job creation without customer details or files
- Handle missing task fields in search API

## Testing
- `npm test` (in taintedpaint)
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_6896e682ceb0832f898f5641a962de38