### PR TITLE
Handle optional fields in job views

### DIFF
--- a/taintedpaint/app/holistic/page.tsx
+++ b/taintedpaint/app/holistic/page.tsx
@@ -97,8 +97,24 @@ export default function ArchivePage() {
       .map(t => ({ ...t, status: getStatus(t) }))
   , [tasks]);
 
-  const customers = useMemo(() => Array.from(new Set(jobs.map(j => j.customerName))), [jobs]);
-  const months    = useMemo(() => Array.from(new Set(jobs.map(j => dayjs(j.inquiryDate).format("YYYY-MM")))), [jobs]);
+  const customers = useMemo(
+    () =>
+      Array.from(
+        new Set(jobs.filter(j => j.customerName).map(j => j.customerName!))
+      ),
+    [jobs]
+  );
+  const months    = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          jobs
+            .filter(j => j.inquiryDate)
+            .map(j => dayjs(j.inquiryDate!).format("YYYY-MM"))
+        )
+      ),
+    [jobs]
+  );
 
   // ② 组件状态 --------------------------------------------------------------------
   const [activeCustomer, setActiveCustomer] = useState<string>('All');
@@ -129,11 +145,16 @@ export default function ArchivePage() {
   const filtered = jobs
     .filter(j => {
       const okCustomer = activeCustomer === "All" || j.customerName === activeCustomer;
-      const okMonth = activeMonth === "All" || dayjs(j.inquiryDate).format("YYYY-MM") === activeMonth;
-      const okSearch = q === "" || j.representative.toLowerCase().includes(q.toLowerCase());
+      const okMonth =
+        activeMonth === "All" || dayjs(j.inquiryDate ?? "").format("YYYY-MM") === activeMonth;
+      const okSearch =
+        q === "" || (j.representative ?? "").toLowerCase().includes(q.toLowerCase());
       return okCustomer && okMonth && okSearch;
     })
-    .sort((a, b) => dayjs(b.inquiryDate).valueOf() - dayjs(a.inquiryDate).valueOf());
+    .sort(
+      (a, b) =>
+        dayjs(b.inquiryDate ?? "").valueOf() - dayjs(a.inquiryDate ?? "").valueOf()
+    );
 
   // ④ 指标计算 --------------------------------------------------------------------
   const working  = filtered.filter(j => j.status === 'Working').length;
@@ -142,7 +163,7 @@ export default function ArchivePage() {
   const denom    = quoted + finished;                        // 已报价 + 已完成
   const hitRate  = denom === 0 ? 0 : Math.round((finished / denom) * 100);
   const byDay = filtered.reduce<Record<string, Job[]>>((acc, job) => {
-    const d = dayjs(job.inquiryDate).format("MMM DD");
+    const d = dayjs(job.inquiryDate ?? "").format("MMM DD");
     (acc[d] = acc[d] || []).push(job);
     return acc;
   }, {});
@@ -302,7 +323,9 @@ function JobCard({ job, onClick }: { job: Job; onClick: () => void }) {
           </span>
         </div>
 
-        <p className="text-xs text-gray-400 mb-3 font-mono tracking-wide">{dayjs(job.inquiryDate).format('YYYY-MM-DD')}</p>
+        <p className="text-xs text-gray-400 mb-3 font-mono tracking-wide">
+          {dayjs(job.inquiryDate ?? "").format('YYYY-MM-DD')}
+        </p>
 
         <div className="flex items-center gap-3 text-xs text-gray-600">
           {job.value ? (

--- a/taintedpaint/components/CreateJobForm.tsx
+++ b/taintedpaint/components/CreateJobForm.tsx
@@ -54,7 +54,9 @@ export default function CreateJobForm({ onJobCreated }: CreateJobFormProps) {
         if (res.ok) {
           const data = await res.json()
           const taskValues = Object.values(data.tasks || {}) as Task[]
-          const names = Array.from(new Set(taskValues.map((t) => t.customerName)))
+          const names = Array.from(
+            new Set(taskValues.map(t => t.customerName).filter(Boolean))
+          ) as string[]
           setCustomerOptions(names)
         }
       } catch {}


### PR DESCRIPTION
## Summary
- avoid undefined dates and names when computing customer/month filters
- guard job search and sorting against missing representative and inquiry dates
- sanitize customer options list when creating new jobs

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896e8db7e74832f8530744c680667a3