### PR TITLE
feat: auto-scroll to accepted task

### DIFF
--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -167,23 +167,32 @@ export default function KanbanBoard() {
   // When we want to spotlight a task, auto-scroll horizontally to reveal it
   useEffect(() => {
     if (!highlightTaskId) return;
-    const node = taskRefs.current.get(highlightTaskId);
     const container = scrollContainerRef.current;
-    if (node && container) {
-      const containerRect = container.getBoundingClientRect();
-      const nodeRect = node.getBoundingClientRect();
-      const scrollPadding = 100;
-      if (nodeRect.left < containerRect.left || nodeRect.right > containerRect.right) {
-        const targetScrollLeft = (node as any).offsetLeft - scrollPadding;
-        container.scrollTo({ left: targetScrollLeft, behavior: "smooth" });
+    let raf = 0;
+    const attemptScroll = () => {
+      const node = taskRefs.current.get(highlightTaskId);
+      if (node && container) {
+        const containerRect = container.getBoundingClientRect();
+        const nodeRect = node.getBoundingClientRect();
+        const scrollPadding = 100;
+        if (nodeRect.left < containerRect.left || nodeRect.right > containerRect.right) {
+          const targetScrollLeft = (node as any).offsetLeft - scrollPadding;
+          container.scrollTo({ left: targetScrollLeft, behavior: "smooth" });
+        }
+        setTimeout(() => {
+          node.scrollIntoView({ behavior: "smooth", block: "center" });
+        }, 300);
+      } else {
+        raf = requestAnimationFrame(attemptScroll);
       }
-      setTimeout(() => {
-        node.scrollIntoView({ behavior: "smooth", block: "center" });
-      }, 300);
-    }
+    };
+    attemptScroll();
     // Auto-clear highlight after a short while so the flash doesn't persist forever
     const clearTimer = setTimeout(() => setHighlightTaskId(null), 6000);
-    return () => clearTimeout(clearTimer);
+    return () => {
+      clearTimeout(clearTimer);
+      cancelAnimationFrame(raf);
+    };
   }, [highlightTaskId]);
 
   // Lightweight board stats (Jira-style overview)


### PR DESCRIPTION
## Summary
- ensure newly accepted tasks scroll into view by attempting scroll until node is mounted

## Testing
- `npm test`
- `npm run lint` *(fails: prompts "How would you like to configure ESLint?")*


------
https://chatgpt.com/codex/tasks/task_e_689703f04978832f8bba161259673da6