### PR TITLE
fix: correct default SMB path

### DIFF
--- a/blackpaint/README.md
+++ b/blackpaint/README.md
@@ -7,7 +7,7 @@ logins to determine whether the full or restricted view is shown.
 ### SMB share
 
 Task folders live on a shared network disk. The application ships with a
-default path of `\\FWQ88\Estara`. If your network share is different, set the
+default path of `\\FWQ888\Estara`. If your network share is different, set the
 `SMB_CLIENT_ROOT` environment variable **before** running `npm run make` so the
 path is embedded into the build, e.g.
 

--- a/blackpaint/src/index.ts
+++ b/blackpaint/src/index.ts
@@ -57,7 +57,7 @@ app.on('ready', () => {
   // This is our new "backend" logic
   ipcMain.handle('open-task-folder', async (_, relativePath: string) => {
     try {
-      const DEFAULT_SMB_ROOT = "\\\\FWQ88\\Estara";
+      const DEFAULT_SMB_ROOT = "\\\\FWQ888\\Estara";
       const smbRoot = process.env.SMB_CLIENT_ROOT || DEFAULT_SMB_ROOT;
       const fullPath = path.join(smbRoot, relativePath);
       const openError = await shell.openPath(fullPath);

--- a/blackpaint/webpack.main.config.ts
+++ b/blackpaint/webpack.main.config.ts
@@ -17,7 +17,7 @@ export const mainConfig: Configuration = {
   plugins: [
     ...plugins,
     new webpack.EnvironmentPlugin({
-      SMB_CLIENT_ROOT: process.env.SMB_CLIENT_ROOT || '\\FWQ88\\Estara',
+      SMB_CLIENT_ROOT: process.env.SMB_CLIENT_ROOT || '\\FWQ888\\Estara',
     }),
   ],
   resolve: {

--- a/blackpaint/webpack.renderer.config.ts
+++ b/blackpaint/webpack.renderer.config.ts
@@ -16,7 +16,7 @@ export const rendererConfig: Configuration = {
   plugins: [
     ...plugins,
     new webpack.EnvironmentPlugin({
-      SMB_CLIENT_ROOT: process.env.SMB_CLIENT_ROOT || '\\FWQ88\\Estara',
+      SMB_CLIENT_ROOT: process.env.SMB_CLIENT_ROOT || '\\FWQ888\\Estara',
     }),
   ],
   resolve: {


### PR DESCRIPTION
## Summary
- default to correct SMB share path

## Testing
- `npm test` (fails: Error: no test specified)
- `cd blackpaint && npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6898244c7a4c832dabb5d8fc99ecc4ba