### PR TITLE
fix: ensure smb path retains network prefix

### DIFF
--- a/blackpaint/webpack.main.config.ts
+++ b/blackpaint/webpack.main.config.ts
@@ -17,7 +17,9 @@ export const mainConfig: Configuration = {
   plugins: [
     ...plugins,
     new webpack.EnvironmentPlugin({
-      SMB_CLIENT_ROOT: process.env.SMB_CLIENT_ROOT || '\\FWQ88\\Estara',
+      // Ensure the default UNC path retains its double leading slashes
+      SMB_CLIENT_ROOT:
+        process.env.SMB_CLIENT_ROOT || '\\\\FWQ88\\Estara',
     }),
   ],
   resolve: {


### PR DESCRIPTION
## Summary
- keep default SMB path with double backslashes so Windows finds the share

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689828ef2ac4832dacde4752ea3311e1