### PR TITLE
Ensure tasks use SMB share for storage

### DIFF
--- a/taintedpaint/app/api/jobs/route.ts
+++ b/taintedpaint/app/api/jobs/route.ts
@@ -15,9 +15,8 @@ import { STORAGE_ROOT, TASKS_STORAGE_DIR, TASKS_DIR_NAME } from "@/lib/storagePa
 
 // --- Path Definitions ---
 // Files are stored on a shared network disk. Configure the root path with the
-// SMB_ROOT environment variable. Defaults to the local `storage` folder for
-// development.
-// `TASKS_STORAGE_DIR` is exported from `lib/storagePaths`.
+// SMB_ROOT environment variable. `TASKS_STORAGE_DIR` is exported from
+// `lib/storagePaths`.
 // ------------------------
 
 // Legacy helper removed in favour of boardDataStore

--- a/taintedpaint/app/storage/[...path]/route.ts
+++ b/taintedpaint/app/storage/[...path]/route.ts
@@ -1,9 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { promises as fs } from 'fs'
 import path from 'path'
+import { STORAGE_ROOT } from '@/lib/storagePaths'
 
-// Serve files from the root-level storage directory
-const STORAGE_DIR = path.join(process.cwd(), '..', 'storage')
+// Serve files from the SMB storage root so clients always access the
+// network share rather than the local server disk.
+const STORAGE_DIR = STORAGE_ROOT
 
 export async function GET(
   _req: NextRequest,

--- a/taintedpaint/lib/boardDataStore.ts
+++ b/taintedpaint/lib/boardDataStore.ts
@@ -1,12 +1,12 @@
 import { mkdirSync } from 'fs'
-import { BOARD_DB_PATH, LOCAL_STORAGE_ROOT } from './storagePaths'
+import { BOARD_DB_PATH, STORAGE_ROOT } from './storagePaths'
 import Database from 'better-sqlite3'
 import { baseColumns, START_COLUMN_ID, ARCHIVE_COLUMN_ID } from './baseColumns'
 import type { BoardData } from '@/types'
 
-// Store dynamic data outside of the public directory so it remains
-// accessible when running `npm run build && npm run start`.
-const STORAGE_DIR = LOCAL_STORAGE_ROOT
+// Store dynamic data on the network share so it remains accessible
+// to all clients and avoids writing to the local server disk.
+const STORAGE_DIR = STORAGE_ROOT
 const DB_PATH = BOARD_DB_PATH
 
 mkdirSync(STORAGE_DIR, { recursive: true })

--- a/taintedpaint/lib/storagePaths.ts
+++ b/taintedpaint/lib/storagePaths.ts
@@ -1,7 +1,12 @@
 import path from 'path'
 
-export const LOCAL_STORAGE_ROOT = path.join(process.cwd(), '..', 'storage')
-export const STORAGE_ROOT = process.env.SMB_ROOT || LOCAL_STORAGE_ROOT
+const SMB_ROOT = process.env.SMB_ROOT
+
+if (!SMB_ROOT) {
+  throw new Error('SMB_ROOT environment variable must point to the SMB share root')
+}
+
+export const STORAGE_ROOT = SMB_ROOT
 export const TASKS_DIR_NAME = '项目'
 export const TASKS_STORAGE_DIR = path.join(STORAGE_ROOT, TASKS_DIR_NAME)
-export const BOARD_DB_PATH = path.join(LOCAL_STORAGE_ROOT, 'board.sqlite')
+export const BOARD_DB_PATH = path.join(STORAGE_ROOT, 'board.sqlite')

--- a/taintedpaint/lib/userStore.ts
+++ b/taintedpaint/lib/userStore.ts
@@ -1,10 +1,10 @@
 import { promises as fs } from 'fs'
 import path from 'path'
 import crypto from 'crypto'
-import { LOCAL_STORAGE_ROOT } from './storagePaths'
+import { STORAGE_ROOT } from './storagePaths'
 import type { User } from '@/types'
 
-const USERS_PATH = path.join(LOCAL_STORAGE_ROOT, 'users.json')
+const USERS_PATH = path.join(STORAGE_ROOT, 'users.json')
 
 async function readUsers(): Promise<User[]> {
   try {


### PR DESCRIPTION
## Summary
- Require SMB_ROOT and point all storage paths to the network share
- Keep board data and users on the SMB share
- Serve files directly from the SMB root instead of local disk

## Testing
- `SMB_ROOT=/tmp/smbroot npm test --prefix taintedpaint`


------
https://chatgpt.com/codex/tasks/task_e_68983081713c832d9a0bed95f5723c7c