### PR TITLE
Store board SQLite locally

### DIFF
--- a/taintedpaint/lib/boardDataStore.ts
+++ b/taintedpaint/lib/boardDataStore.ts
@@ -1,12 +1,11 @@
 import { mkdirSync } from 'fs'
-import { BOARD_DB_PATH, STORAGE_ROOT } from './storagePaths'
+import { BOARD_DB_PATH, LOCAL_STORAGE_ROOT } from './storagePaths'
 import Database from 'better-sqlite3'
 import { baseColumns, START_COLUMN_ID, ARCHIVE_COLUMN_ID } from './baseColumns'
 import type { BoardData } from '@/types'
 
-// Store dynamic data on the network share so it remains accessible
-// to all clients and avoids writing to the local server disk.
-const STORAGE_DIR = STORAGE_ROOT
+// Store board metadata locally so the SMB share only holds task files.
+const STORAGE_DIR = LOCAL_STORAGE_ROOT
 const DB_PATH = BOARD_DB_PATH
 
 mkdirSync(STORAGE_DIR, { recursive: true })

--- a/taintedpaint/lib/storagePaths.ts
+++ b/taintedpaint/lib/storagePaths.ts
@@ -9,4 +9,7 @@ if (!SMB_ROOT) {
 export const STORAGE_ROOT = SMB_ROOT
 export const TASKS_DIR_NAME = '项目'
 export const TASKS_STORAGE_DIR = path.join(STORAGE_ROOT, TASKS_DIR_NAME)
-export const BOARD_DB_PATH = path.join(STORAGE_ROOT, 'board.sqlite')
+
+// Store SQLite metadata locally rather than on the SMB share
+export const LOCAL_STORAGE_ROOT = path.resolve(__dirname, '..', '..', 'storage')
+export const BOARD_DB_PATH = path.join(LOCAL_STORAGE_ROOT, 'board.sqlite')


### PR DESCRIPTION
## Summary
- keep tasks on the SMB share but save the board's SQLite database in the repo's local `storage` directory

## Testing
- `SMB_ROOT=/tmp npm test`


------
https://chatgpt.com/codex/tasks/task_e_68983b734d84832d8c65f25917e85bc2