### PR TITLE
fix: improve signup route error handling

### DIFF
--- a/taintedpaint/app/api/signup/route.ts
+++ b/taintedpaint/app/api/signup/route.ts
@@ -12,6 +12,13 @@ export async function POST(req: NextRequest) {
     const user = await addUser(name, department, password)
     return NextResponse.json({ user })
   } catch (err) {
-    return NextResponse.json({ error: 'User exists' }, { status: 400 })
+    if (err instanceof Error && err.message === 'User exists') {
+      return NextResponse.json({ error: err.message }, { status: 400 })
+    }
+    console.error(err)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
   }
 }


### PR DESCRIPTION
## Summary
- handle signup errors explicitly and surface internal server issues

## Testing
- `cd taintedpaint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68999d667798832da5c62c84c1067eb8