### PR TITLE
fix: persist board data in server volume

### DIFF
--- a/taintedpaint/lib/storagePaths.ts
+++ b/taintedpaint/lib/storagePaths.ts
@@ -1,16 +1,8 @@
 import path from 'path'
 
-const SMB_ROOT = process.env.SMB_ROOT
+// Root of the shared SMB storage. If not provided, paths will be stored as-is.
+export const STORAGE_ROOT = process.env.SMB_ROOT || ''
 
-if (!SMB_ROOT) {
-  throw new Error('SMB_ROOT environment variable must point to the SMB share root')
-}
-
-// All task folders already live directly on the SMB share. We simply store
-// references to those folders instead of copying files into a separate
-// subdirectory.
-export const STORAGE_ROOT = SMB_ROOT
-
-// Store SQLite metadata locally rather than on the SMB share
-export const LOCAL_STORAGE_ROOT = path.resolve(__dirname, '..', '..', 'storage')
+// Keep the SQLite board on the server's persistent data volume
+export const LOCAL_STORAGE_ROOT = process.env.LOCAL_STORAGE_ROOT || '/data'
 export const BOARD_DB_PATH = path.join(LOCAL_STORAGE_ROOT, 'board.sqlite')


### PR DESCRIPTION
## Summary
- remove hard SMB_ROOT requirement and allow storing paths as-is
- persist kanban board in `/data/board.sqlite` for reliable refreshes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899a71c3878832da0951d6ad40241bb