### PR TITLE
Add open task folder button to task modal

### DIFF
--- a/taintedpaint/components/TaskModal.tsx
+++ b/taintedpaint/components/TaskModal.tsx
@@ -207,12 +207,15 @@ export default function TaskModal({
             </h2>
 
             <div className="flex items-center gap-2">
-              {task.taskFolderPath && (
-                <ActionButton onClick={handleOpenTask} variant="neutral" title="打开任务">
-                  <Folder className="h-4 w-4" />
-                  打开任务
-                </ActionButton>
-              )}
+              <ActionButton
+                onClick={handleOpenTask}
+                variant="neutral"
+                title="打开文件夹"
+                disabled={!task.taskFolderPath}
+              >
+                <Folder className="h-4 w-4" />
+                打开文件夹
+              </ActionButton>
               <ActionButton onClick={() => onOpenChange(false)} variant="subtle" title="关闭">
                 <X className="h-4 w-4" />
               </ActionButton>


### PR DESCRIPTION
## Summary
- Always render "Open Folder" button in TaskModal to access task SMB path
- Disable the button when no task folder is available

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6899ade311fc832d91df8b1b5481480d