### PR TITLE
Preserve task folder path in job summaries

### DIFF
--- a/taintedpaint/app/api/jobs/route.ts
+++ b/taintedpaint/app/api/jobs/route.ts
@@ -34,6 +34,7 @@ export async function GET(req: NextRequest) {
           inquiryDate: t.inquiryDate,
           deliveryDate: t.deliveryDate,
           notes: t.notes,
+          taskFolderPath: t.taskFolderPath,
           ynmxId: t.ynmxId,
           deliveryNoteGenerated: t.deliveryNoteGenerated,
           awaitingAcceptance: t.awaitingAcceptance,

--- a/taintedpaint/types.ts
+++ b/taintedpaint/types.ts
@@ -43,6 +43,7 @@ export interface TaskSummary {
   inquiryDate?: string;
   deliveryDate?: string;
   notes?: string;
+  taskFolderPath?: string;
   ynmxId?: string;
   deliveryNoteGenerated?: boolean;
   awaitingAcceptance?: boolean;


### PR DESCRIPTION
## Summary
- include `taskFolderPath` in `TaskSummary`
- return `taskFolderPath` from the `/api/jobs?summary=1` endpoint so folder references survive board saves

## Testing
- `cd taintedpaint && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899b16cad10832d848460bb0d863a66