### PR TITLE
Fix SMB path configuration for tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,13 @@ share.
 3. Enable **Share this folder** and set a share name (for example `CrystalData`).
 4. Click **Permissions** and grant **Read/Write** access to the users that will
    connect (or `Everyone` on a trusted local network).
-5. Note the UNC path of the share, e.g. `\\YOUR-SERVER\CrystalData`.
+5. Note the UNC path to the folder that holds your task directories,
+   e.g. `\\YOUR-SERVER\CrystalData\Estara\Tasks`.
 6. Set the environment variable `SMB_ROOT` to this UNC path when starting the
    Next.js server:
 
    ```cmd
-   set SMB_ROOT=\\YOUR-SERVER\CrystalData
+   set SMB_ROOT=\\YOUR-SERVER\CrystalData\Estara\Tasks
    npm run build && npm run start
    ```
 
@@ -81,11 +82,11 @@ share.
 
 1. Make sure the same share is accessible from each workstation. You can map it
    to a drive letter or access it directly via the UNC path.
-2. Set the environment variable `SMB_CLIENT_ROOT` to the UNC path before
+2. Set the environment variable `SMB_CLIENT_ROOT` to the same UNC path before
    launching the Electron app:
 
    ```cmd
-   set SMB_CLIENT_ROOT=\\YOUR-SERVER\CrystalData
+   set SMB_CLIENT_ROOT=\\YOUR-SERVER\CrystalData\Estara\Tasks
    npm run start
    ```
 

--- a/blackpaint/src/index.ts
+++ b/blackpaint/src/index.ts
@@ -57,7 +57,7 @@ app.on('ready', () => {
   // This is our new "backend" logic
   ipcMain.handle('open-task', async (_, relativePath: string) => {
     try {
-      const DEFAULT_SMB_ROOT = "\\\\192.168.5.21\\d\\Estara\\Tasks";
+      const DEFAULT_SMB_ROOT = String.raw`\\192.168.5.21\d\Estara\Tasks`;
       const smbRoot = process.env.SMB_CLIENT_ROOT || DEFAULT_SMB_ROOT;
       const targetPath = path.isAbsolute(relativePath)
         ? relativePath

--- a/blackpaint/webpack.main.config.ts
+++ b/blackpaint/webpack.main.config.ts
@@ -19,7 +19,7 @@ export const mainConfig: Configuration = {
     new webpack.EnvironmentPlugin({
       // Ensure the default UNC path retains its double leading slashes
       SMB_CLIENT_ROOT:
-        process.env.SMB_CLIENT_ROOT || '\\\\FWQ888\\Estara',
+        process.env.SMB_CLIENT_ROOT || String.raw`\\192.168.5.21\d\Estara\Tasks`,
     }),
   ],
   resolve: {

--- a/taintedpaint/lib/storagePaths.ts
+++ b/taintedpaint/lib/storagePaths.ts
@@ -4,7 +4,7 @@ import path from 'path'
 // organisation. Can be overridden by setting the `SMB_ROOT` environment
 // variable on the server.
 export const STORAGE_ROOT =
-  process.env.SMB_ROOT || "\\\\192.168.5.21\\d\\Estara\\Tasks"
+  process.env.SMB_ROOT || String.raw`\\192.168.5.21\d\Estara\Tasks`
 
 // Keep the SQLite board on the server's persistent data volume
 export const LOCAL_STORAGE_ROOT = process.env.LOCAL_STORAGE_ROOT || '/data'


### PR DESCRIPTION
## Summary
- ensure default SMB paths include `Estara\Tasks` and use raw strings
- document that `SMB_ROOT`/`SMB_CLIENT_ROOT` must point to the tasks directory

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6899d14830a4832d8e72de1f177bd5d9