### PR TITLE
fix: serve files with array buffer

### DIFF
--- a/taintedpaint/app/storage/[...path]/route.ts
+++ b/taintedpaint/app/storage/[...path]/route.ts
@@ -19,7 +19,14 @@ export async function GET(
   }
   try {
     const data = await fs.readFile(normalised)
-    return new NextResponse(data)
+    // fs.readFile returns a Node Buffer which isn't directly accepted by
+    // the NextResponse constructor's `BodyInit` type. Convert the buffer to
+    // an ArrayBuffer so the Response can be constructed without type errors.
+    const arrayBuffer = data.buffer.slice(
+      data.byteOffset,
+      data.byteOffset + data.byteLength,
+    ) as ArrayBuffer
+    return new NextResponse(arrayBuffer)
   } catch (err: any) {
     if (err.code === 'ENOENT') {
       return new NextResponse('Not Found', { status: 404 })


### PR DESCRIPTION
## Summary
- convert fs.readFile Buffer to ArrayBuffer before creating NextResponse

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a9df8b300832d8a956fc4adf8f0ba