### PR TITLE
Hide customer details from non-business users

### DIFF
--- a/taintedpaint/app/api/jobs/[taskId]/update/route.ts
+++ b/taintedpaint/app/api/jobs/[taskId]/update/route.ts
@@ -46,11 +46,11 @@ export async function PATCH(
       const changes: string[] = [];
       if (typeof customerName === 'string' && customerName.trim() !== t.customerName) {
         t.customerName = customerName.trim();
-        changes.push(`将客户名称改为 ${t.customerName}`);
+        changes.push('更新客户名称');
       }
       if (typeof representative === 'string' && representative.trim() !== t.representative) {
         t.representative = representative.trim();
-        changes.push(`将负责人改为 ${t.representative}`);
+        changes.push('更新负责人');
       }
       if (typeof ynmxId === 'string') {
         const trimmed = ynmxId.trim();

--- a/taintedpaint/components/KanbanColumn.tsx
+++ b/taintedpaint/components/KanbanColumn.tsx
@@ -82,6 +82,7 @@ export default function KanbanColumn({
 }: KanbanColumnProps) {
   const todayStr = new Date().toISOString().slice(0, 10);
   const bodyRef = useRef<HTMLDivElement>(null);
+  const hideNames = viewMode === "production" || isRestricted;
 
   useEffect(() => {
     if (openPending[column.id]) {
@@ -174,7 +175,7 @@ export default function KanbanColumn({
                   .filter((t) => !column.taskIds.includes((t as any).id))
                   .filter((t) => {
                     if (q === "") return true;
-                    const text = isRestricted
+                    const text = hideNames
                       ? `${t.ynmxId || ""}`.toLowerCase()
                       : `${t.customerName} ${t.representative} ${t.ynmxId || ""} ${t.notes || ""}`.toLowerCase();
                     return text.includes(q);
@@ -192,7 +193,7 @@ export default function KanbanColumn({
                       className="w-full text-left px-3 py-2 hover:bg-gray-50 rounded-[2px] transition-colors"
                     >
                       <div className="min-w-0">
-                        {isRestricted ? (
+                        {hideNames ? (
                           <div className="text-sm font-medium text-gray-900 truncate">
                             {(t as any).ynmxId || "—"}
                           </div>
@@ -263,9 +264,9 @@ export default function KanbanColumn({
                       <h3 className="text-sm font-medium text-gray-900 truncate">
                         {getTaskDisplayName(task)}
                       </h3>
-                      {!isRestricted && (
+              {!hideNames && (
                         <p className="text-xs text-gray-600">{task.representative}</p>
-                      )}
+              )}
                     </div>
                     <div className="flex gap-1 ml-2 flex-shrink-0">
                       <button

--- a/taintedpaint/components/TaskCard.tsx
+++ b/taintedpaint/components/TaskCard.tsx
@@ -35,9 +35,7 @@ export default function TaskCard({
   const titleNode =
     viewMode === "business"
       ? searchRender(task.customerName) || "未命名客户"
-      : isRestricted
-      ? searchRender(task.ynmxId || "—")
-      : searchRender(task.ynmxId || `${task.customerName || ""} - ${task.representative || ""}`);
+      : searchRender(task.ynmxId || "—");
 
   return (
     <div
@@ -55,7 +53,7 @@ export default function TaskCard({
       <h3 className="truncate text-[13px] leading-snug font-medium text-gray-900">{titleNode}</h3>
 
       <div className="mt-2 flex flex-wrap gap-1">
-        {task.representative && !isRestricted && (
+        {viewMode === "business" && task.representative && !isRestricted && (
           <span className="px-2 py-0.5 rounded-[2px] bg-gray-100 text-gray-700 text-[11px] font-medium">
             {searchRender(task.representative)}
           </span>

--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -59,12 +59,18 @@ export default function KanbanBoard() {
   const latestFetchRef = useRef(0);
 
   // Search match helper (simple .includes across a few fields)
-  const doesTaskMatchQuery = useCallback((task: TaskSummary & Partial<Task>, q: string) => {
-    const query = q.trim().toLowerCase();
-    if (query === "") return true;
-    const haystack = `${task.customerName || ""} ${task.representative || ""} ${task.ynmxId || ""} ${task.notes || ""}`.toLowerCase();
-    return haystack.includes(query);
-  }, []);
+  const doesTaskMatchQuery = useCallback(
+    (task: TaskSummary & Partial<Task>, q: string) => {
+      const query = q.trim().toLowerCase();
+      if (query === "") return true;
+      let haystack = `${task.ynmxId || ""} ${task.notes || ""}`.toLowerCase();
+      if (viewMode === "business" && !isRestricted) {
+        haystack += ` ${task.customerName || ""} ${task.representative || ""}`;
+      }
+      return haystack.includes(query);
+    },
+    [viewMode, isRestricted]
+  );
 
   // Highlight matched text spans with <mark> (cheap visual)
   const renderHighlighted = useCallback((text: string | undefined, q: string) => {
@@ -260,11 +266,8 @@ export default function KanbanBoard() {
 
   // Display name differs by viewMode
   const getTaskDisplayName = (task: TaskSummary) => {
-    if (isRestricted) {
+    if (viewMode === "production" || isRestricted) {
       return task.ynmxId || "—";
-    }
-    if (viewMode === "production") {
-      return task.ynmxId || `${task.customerName} - ${task.representative}`;
     }
     return `${task.customerName} - ${task.representative}`;
   };


### PR DESCRIPTION
## Summary
- conceal customer and representative info from users outside the 商务 department, showing only YNMX IDs
- sanitize task history and search logic so sensitive fields are not exposed
- adjust holistic archive view to respect user role and forward viewMode to modals

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_689aa80b0734832db199c5a082763c33