### PR TITLE
Make archived tasks searchable and group by day

### DIFF
--- a/taintedpaint/app/api/search/route.ts
+++ b/taintedpaint/app/api/search/route.ts
@@ -15,7 +15,6 @@ export async function GET(req: NextRequest) {
     const colMap = new Map(data.columns.map((c) => [c.id, c.title]));
     const results = Object.values(data.tasks as Record<string, Task>)
       .filter((task) => {
-        if (task.columnId === 'archive' || task.columnId === 'archive2') return false;
         const text = `${task.customerName} ${task.representative} ${task.ynmxId ?? ''} ${task.notes ?? ''}`.toLowerCase();
         return text.includes(query);
       })

--- a/taintedpaint/components/KanbanColumn.tsx
+++ b/taintedpaint/components/KanbanColumn.tsx
@@ -312,43 +312,61 @@ export default function KanbanColumn({
             </div>
           </div>
         ) : (
-          columnTasks.map((task, index) => (
-            <div key={task.id} className="relative group">
-              <div
-                ref={(node) => {
-                  if (node) taskRefs.current.set(task.id, node);
-                  else taskRefs.current.delete(task.id);
-                }}
-              >
-                <TaskCard
-                  task={task as any}
-                  viewMode={viewMode}
-                  isRestricted={isRestricted}
-                  searchRender={(txt?: string) => renderHighlighted(txt, searchQuery)}
-                  isHighlighted={highlightTaskId === task.id}
-                  onClick={(e) => handleTaskClick(task as Task, e)}
-                  draggableProps={{
-                    draggable: true,
-                    onDragStart: (e) => handleDragStart(e, task as any, column.id),
-                    onDragEnd: handleDragEnd,
-                    onDragOver: (e) => handleDragOverTask(e, index, column.id),
-                  }}
-                />
-              </div>
-              <button
-                className="absolute top-1 right-1 hidden group-hover:inline-flex p-1 rounded-[2px] bg-white text-gray-400 hover:bg-gray-100"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleRemoveTask(task.id, column.id);
-                }}
-              >
-                <X className="w-3 h-3" />
-              </button>
-              {dragOverColumn === column.id && dropIndicatorIndex === index + 1 && (
-                <div className="h-0.5 bg-blue-500 mt-2 animate-pulse" />
-              )}
-            </div>
-          ))
+          (() => {
+            const nodes: React.ReactNode[] = [];
+            let lastDate = "";
+            columnTasks.forEach((task, index) => {
+              if (isArchive) {
+                const d = (task.updatedAt || task.createdAt || "").slice(0, 10);
+                if (d !== lastDate) {
+                  nodes.push(
+                    <div key={`hdr-${d}`} className="mt-4 mb-2 text-xs font-semibold text-gray-500">
+                      {d || "未知日期"}
+                    </div>
+                  );
+                  lastDate = d;
+                }
+              }
+              nodes.push(
+                <div key={task.id} className="relative group">
+                  <div
+                    ref={(node) => {
+                      if (node) taskRefs.current.set(task.id, node);
+                      else taskRefs.current.delete(task.id);
+                    }}
+                  >
+                    <TaskCard
+                      task={task as any}
+                      viewMode={viewMode}
+                      isRestricted={isRestricted}
+                      searchRender={(txt?: string) => renderHighlighted(txt, searchQuery)}
+                      isHighlighted={highlightTaskId === task.id}
+                      onClick={(e) => handleTaskClick(task as Task, e)}
+                      draggableProps={{
+                        draggable: true,
+                        onDragStart: (e) => handleDragStart(e, task as any, column.id),
+                        onDragEnd: handleDragEnd,
+                        onDragOver: (e) => handleDragOverTask(e, index, column.id),
+                      }}
+                    />
+                  </div>
+                  <button
+                    className="absolute top-1 right-1 hidden group-hover:inline-flex p-1 rounded-[2px] bg-white text-gray-400 hover:bg-gray-100"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleRemoveTask(task.id, column.id);
+                    }}
+                  >
+                    <X className="w-3 h-3" />
+                  </button>
+                  {dragOverColumn === column.id && dropIndicatorIndex === index + 1 && (
+                    <div className="h-0.5 bg-blue-500 mt-2 animate-pulse" />
+                  )}
+                </div>
+              );
+            });
+            return nodes;
+          })()
         )}
       </div>
     </div>

--- a/taintedpaint/lib/boardDataStore.ts
+++ b/taintedpaint/lib/boardDataStore.ts
@@ -41,16 +41,12 @@ function normalizeBoardData(data: BoardData) {
     col.taskIds = Array.from(new Set(
       col.taskIds.filter(id => {
         const t = (data.tasks as Record<string, any>)[id]
-        return t && !t.awaitingAcceptance && t.columnId !== ARCHIVE_COLUMN_ID && t.columnId !== 'archive2'
+        return t && !t.awaitingAcceptance && t.columnId === col.id
       })
     ))
   }
 
   for (const [id, task] of Object.entries(data.tasks)) {
-    if (task.columnId === ARCHIVE_COLUMN_ID || task.columnId === 'archive2') {
-      delete data.tasks[id]
-      continue
-    }
     if (!columnIds.has(task.columnId)) {
       task.columnId = ARCHIVE_COLUMN_ID
     }


### PR DESCRIPTION
## Summary
- retain archived tasks in board data and include them in search results
- sort archive columns by last update and group cards under date headers

## Testing
- `npm test` (taintedpaint)
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_689aad0184e8832dbfd09e8ad8582a4c