### PR TITLE
Keep archived tasks visible and searchable

### DIFF
--- a/taintedpaint/app/api/search/route.ts
+++ b/taintedpaint/app/api/search/route.ts
@@ -15,7 +15,6 @@ export async function GET(req: NextRequest) {
     const colMap = new Map(data.columns.map((c) => [c.id, c.title]));
     const results = Object.values(data.tasks as Record<string, Task>)
       .filter((task) => {
-        if (task.columnId === 'archive' || task.columnId === 'archive2') return false;
         const text = `${task.customerName} ${task.representative} ${task.ynmxId ?? ''} ${task.notes ?? ''}`.toLowerCase();
         return text.includes(query);
       })

--- a/taintedpaint/components/TaskCard.tsx
+++ b/taintedpaint/components/TaskCard.tsx
@@ -11,6 +11,7 @@ export default function TaskCard({
   isRestricted,
   searchRender,
   isHighlighted,
+  isArchive = false,
   onClick,
   draggableProps,
 }: {
@@ -19,6 +20,7 @@ export default function TaskCard({
   isRestricted: boolean;
   searchRender: (text?: string) => React.ReactNode;
   isHighlighted: boolean;
+  isArchive?: boolean;
   onClick: (e: React.MouseEvent) => void;
   draggableProps: {
     draggable: boolean;
@@ -49,7 +51,12 @@ export default function TaskCard({
       ].join(" ")}
     >
       {/* Left status strip based on column */}
-      <div aria-hidden="true" className={`absolute left-0 top-0 bottom-0 w-[3px] rounded-l-[2px] ${stripClass}`} />
+      {!isArchive && (
+        <div
+          aria-hidden="true"
+          className={`absolute left-0 top-0 bottom-0 w-[3px] rounded-l-[2px] ${stripClass}`}
+        />
+      )}
       <h3 className="truncate text-[13px] leading-snug font-medium text-gray-900">{titleNode}</h3>
 
       <div className="mt-2 flex flex-wrap gap-1">

--- a/taintedpaint/lib/boardDataStore.ts
+++ b/taintedpaint/lib/boardDataStore.ts
@@ -41,16 +41,12 @@ function normalizeBoardData(data: BoardData) {
     col.taskIds = Array.from(new Set(
       col.taskIds.filter(id => {
         const t = (data.tasks as Record<string, any>)[id]
-        return t && !t.awaitingAcceptance && t.columnId !== ARCHIVE_COLUMN_ID && t.columnId !== 'archive2'
+        return t && !t.awaitingAcceptance && t.columnId === col.id
       })
     ))
   }
 
   for (const [id, task] of Object.entries(data.tasks)) {
-    if (task.columnId === ARCHIVE_COLUMN_ID || task.columnId === 'archive2') {
-      delete data.tasks[id]
-      continue
-    }
     if (!columnIds.has(task.columnId)) {
       task.columnId = ARCHIVE_COLUMN_ID
     }


### PR DESCRIPTION
## Summary
- retain archived tasks in board storage and include them in search results
- group archived column tasks by updated date with day headers and remove status stripes
- sort archive columns by updated time and keep tasks when dropped there

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_689ab14e4410832db278456f9c7d2c24