### PR TITLE
Allow task duplication across columns and smoother completion

### DIFF
--- a/taintedpaint/lib/boardDataStore.ts
+++ b/taintedpaint/lib/boardDataStore.ts
@@ -31,19 +31,23 @@ function normalizeBoardData(data: BoardData) {
 
   // Normalize task arrays in columns
   for (const col of data.columns) {
-    col.pendingTaskIds = Array.from(new Set(
-      (col.pendingTaskIds || []).filter(id => {
-        const t = (data.tasks as Record<string, any>)[id]
-        return t && t.awaitingAcceptance && t.columnId === col.id
-      })
-    ))
+    col.pendingTaskIds = Array.from(
+      new Set(
+        (col.pendingTaskIds || []).filter(id => {
+          const t = (data.tasks as Record<string, any>)[id]
+          return t && t.awaitingAcceptance
+        })
+      )
+    )
 
-    col.taskIds = Array.from(new Set(
-      col.taskIds.filter(id => {
-        const t = (data.tasks as Record<string, any>)[id]
-        return t && !t.awaitingAcceptance && t.columnId === col.id
-      })
-    ))
+    col.taskIds = Array.from(
+      new Set(
+        col.taskIds.filter(id => {
+          const t = (data.tasks as Record<string, any>)[id]
+          return !!t
+        })
+      )
+    )
   }
 
   for (const [id, task] of Object.entries(data.tasks)) {


### PR DESCRIPTION
## Summary
- Keep tasks in their original column when dragged to a new column
- Support multiple column references in board storage
- Enlarge completion checkmark with fade-out animation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ad45b2738832d91cfba4dd57f3838