### PR TITLE
Refactor pending tasks to be column-specific

### DIFF
--- a/taintedpaint/app/api/jobs/route.ts
+++ b/taintedpaint/app/api/jobs/route.ts
@@ -37,7 +37,6 @@ export async function GET(req: NextRequest) {
           notes: t.notes,
           ynmxId: t.ynmxId,
           deliveryNoteGenerated: t.deliveryNoteGenerated,
-          awaitingAcceptance: t.awaitingAcceptance,
           updatedAt: t.updatedAt,
           updatedBy: t.updatedBy,
         },
@@ -82,7 +81,6 @@ export async function POST(req: NextRequest) {
       taskFolderPath,
       files: [],
       deliveryNoteGenerated: false,
-      awaitingAcceptance: false,
       updatedAt: now,
       updatedBy: updatedBy.trim() || undefined,
       history: updatedBy

--- a/taintedpaint/app/holistic/page.tsx
+++ b/taintedpaint/app/holistic/page.tsx
@@ -99,9 +99,9 @@ export default function ArchivePage() {
 
   const jobs = useMemo<Job[]>(() =>
     Object.values(tasks)
-      .filter(t => !t.awaitingAcceptance)
+      .filter(t => columns.some(c => c.taskIds.includes(t.id)))
       .map(t => ({ ...t, status: getStatus(t) }))
-  , [tasks]);
+  , [tasks, columns]);
 
   const customers = useMemo(() => {
     if (viewMode !== 'business') return [];

--- a/taintedpaint/lib/boardDataStore.ts
+++ b/taintedpaint/lib/boardDataStore.ts
@@ -35,7 +35,7 @@ function normalizeBoardData(data: BoardData) {
       new Set(
         (col.pendingTaskIds || []).filter(id => {
           const t = (data.tasks as Record<string, any>)[id]
-          return t && t.awaitingAcceptance
+          return !!t
         })
       )
     )
@@ -50,13 +50,10 @@ function normalizeBoardData(data: BoardData) {
     )
   }
 
-  for (const [id, task] of Object.entries(data.tasks)) {
+  for (const task of Object.values(data.tasks)) {
     if (!columnIds.has(task.columnId)) {
       task.columnId = ARCHIVE_COLUMN_ID
     }
-    const col = columnMap.get(task.columnId) || archiveCol
-    const list = task.awaitingAcceptance ? col.pendingTaskIds : col.taskIds
-    if (!list.includes(id)) list.push(id)
   }
 }
 

--- a/taintedpaint/types.ts
+++ b/taintedpaint/types.ts
@@ -15,8 +15,6 @@ export interface Task {
   files?: string[];
   ynmxId?: string; // Order ID provided by users
   deliveryNoteGenerated?: boolean;
-  /** Whether this task is waiting for acceptance in the target column */
-  awaitingAcceptance?: boolean;
   /** ISO timestamp when the task was created */
   createdAt?: string;
   /** ISO timestamp of the last modification */
@@ -45,7 +43,6 @@ export interface TaskSummary {
   notes?: string;
   ynmxId?: string;
   deliveryNoteGenerated?: boolean;
-  awaitingAcceptance?: boolean;
   /** ISO timestamp when the task was created */
   createdAt?: string;
   /** ISO timestamp of the last modification */


### PR DESCRIPTION
## Summary
- keep tasks when dragging between columns and track pending state per column
- drop global `awaitingAcceptance` flag from tasks and API
- update archive view and data store to derive pending tasks from column lists

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689adb071ba8832db28e1cd86b6f3d73