### PR TITLE
fix: keep declined tasks on board

### DIFF
--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -676,15 +676,15 @@ export default function KanbanBoard() {
   };
 
   // Decline task from pending area
-  const handleDeclineTask = async (taskId: string, _columnId: string) => {
-    if (!tasks[taskId]) return;
-    const nextTasks = { ...tasks };
-    delete nextTasks[taskId];
-    let nextColumns = columns.map((col) => ({
-      ...col,
-      taskIds: col.taskIds.filter((id) => id !== taskId),
-      pendingTaskIds: col.pendingTaskIds.filter((id) => id !== taskId),
-    }));
+  const handleDeclineTask = async (taskId: string, columnId: string) => {
+    const task = tasks[taskId];
+    if (!task) return;
+    const nextTasks = { ...tasks, [taskId]: { ...task, previousColumnId: undefined } };
+    let nextColumns = columns.map((col) =>
+      col.id === columnId
+        ? { ...col, pendingTaskIds: col.pendingTaskIds.filter((id) => id !== taskId) }
+        : col
+    );
     nextColumns = sortColumnsData(nextColumns, nextTasks as any);
     setTasks(nextTasks);
     setColumns(nextColumns);


### PR DESCRIPTION
## Summary
- avoid deleting tasks when declining in pending drawer
- only remove task from the column's pending list

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689ade66c310832dae24ba0346a241a9