### PR TITLE
Highlight newly added tasks in board

### DIFF
--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -132,6 +132,8 @@ export default function KanbanBoard() {
     nextColumns = sortColumnsData(nextColumns, nextTasks as any);
     setTasks(nextTasks);
     setColumns(nextColumns);
+    // Spotlight the task we just added so it doesn't get lost
+    setHighlightTaskId(taskId);
     await saveBoard({ tasks: nextTasks as any, columns: nextColumns });
   };
 
@@ -768,6 +770,8 @@ export default function KanbanBoard() {
       );
       return next;
     });
+    // Auto-scroll and highlight the new task so it's visible
+    setHighlightTaskId(newTask.id);
   };
 
   // Open task modal


### PR DESCRIPTION
## Summary
- highlight and auto-scroll when adding existing tasks to a column
- highlight new tasks created via form

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b38877c90832db87a1a62a98e9b1f