### PR TITLE
Search pending tasks and auto-open inbox

### DIFF
--- a/taintedpaint/components/KanbanColumn.tsx
+++ b/taintedpaint/components/KanbanColumn.tsx
@@ -279,11 +279,13 @@ export default function KanbanColumn({
                   <div className="flex items-start justify-between">
                     <div className="flex-1 min-w-0">
                       <h3 className="text-sm font-medium text-gray-900 truncate">
-                        {getTaskDisplayName(task)}
+                        {renderHighlighted(getTaskDisplayName(task), searchQuery)}
                       </h3>
-              {!hideNames && (
-                        <p className="text-xs text-gray-600">{task.representative}</p>
-              )}
+                      {!hideNames && (
+                        <p className="text-xs text-gray-600">
+                          {renderHighlighted(task.representative, searchQuery)}
+                        </p>
+                      )}
                     </div>
                     <div className="flex gap-1 ml-2 flex-shrink-0">
                       <button

--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -265,6 +265,28 @@ export default function KanbanBoard() {
     []
   );
 
+  // Auto-open pending sections when search matches a task in the inbox
+  useEffect(() => {
+    if (!searchQuery) return;
+    setOpenPending((prev) => {
+      let changed = false;
+      const next = { ...prev };
+      for (const col of columns) {
+        const hasMatch = col.pendingTaskIds
+          .map((id) => tasks[id])
+          .filter(Boolean)
+          .filter((t) => doesTaskMatchQuery(t as any, searchQuery))
+          .filter((t) => (activeFilter ? matchesStatFilter(t as any, activeFilter) : true))
+          .length > 0;
+        if (hasMatch && !next[col.id]) {
+          next[col.id] = true;
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [searchQuery, columns, tasks, doesTaskMatchQuery, activeFilter, matchesStatFilter]);
+
   // Display name differs by viewMode
   const getTaskDisplayName = (task: TaskSummary) => {
     if (viewMode === "production" || isRestricted) {
@@ -923,6 +945,7 @@ export default function KanbanBoard() {
             const pendingTasks = column.pendingTaskIds
               .map((id) => tasks[id])
               .filter(Boolean)
+              .filter((t) => doesTaskMatchQuery(t as any, searchQuery))
               .filter((t) => (activeFilter ? matchesStatFilter(t as any, activeFilter) : true));
             const isArchive = ["archive", "archive2"].includes(column.id);
 


### PR DESCRIPTION
## Summary
- Include pending task inbox items in board search
- Auto-expand pending sections when search matches a task
- Highlight search matches in pending task display

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689bef938a08832d9822206a40972efe