### PR TITLE
Add quick move action for Kanban tasks

### DIFF
--- a/taintedpaint/components/KanbanColumn.tsx
+++ b/taintedpaint/components/KanbanColumn.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import React, { useEffect, useRef, useMemo } from "react";
-import { Archive, Plus, Search, X, Check } from "lucide-react";
+import React, { useEffect, useRef, useMemo, useState } from "react";
+import { Archive, Plus, Search, X, Check, ArrowRight } from "lucide-react";
 import TaskCard from "@/components/TaskCard";
 import type { Task, TaskSummary, Column } from "@/types";
 
@@ -38,6 +38,7 @@ interface KanbanColumnProps {
   animateAcceptPending: (taskId: string, columnId: string) => void;
   animateDeclinePending: (taskId: string, columnId: string) => void;
   animateCompleteTask: (taskId: string, columnId: string) => void;
+  handleMoveTask: (taskId: string, sourceColumnId: string, targetColumnId: string) => void;
   completing: Record<string, boolean>;
   getTaskDisplayName: (task: TaskSummary) => string;
   acceptingPending: Record<string, boolean>;
@@ -77,6 +78,7 @@ export default function KanbanColumn({
   animateAcceptPending,
   animateDeclinePending,
   animateCompleteTask,
+  handleMoveTask,
   completing,
   getTaskDisplayName,
   acceptingPending,
@@ -85,6 +87,7 @@ export default function KanbanColumn({
   const todayStr = new Date().toISOString().slice(0, 10);
   const bodyRef = useRef<HTMLDivElement>(null);
   const hideNames = viewMode === "production" || isRestricted;
+  const [moveMenuFor, setMoveMenuFor] = useState<string | null>(null);
 
   const archiveGroups = useMemo(() => {
     if (!isArchive) return [];
@@ -368,6 +371,34 @@ export default function KanbanColumn({
                         />
                       </div>
                       <button
+                        className="absolute top-1 right-7 hidden group-hover:inline-flex p-1.5 rounded-[2px] bg-white text-gray-400 hover:bg-gray-100 hover:text-blue-600 transition-transform duration-150 hover:scale-110"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setMoveMenuFor(moveMenuFor === task.id ? null : task.id);
+                        }}
+                      >
+                        <ArrowRight className="w-4 h-4" />
+                      </button>
+                      {moveMenuFor === task.id && (
+                        <div className="absolute top-8 right-1 z-20 rounded-[2px] border border-gray-200 bg-white shadow-md">
+                          {columns
+                            .filter((c) => c.id !== column.id)
+                            .map((c) => (
+                              <button
+                                key={c.id}
+                                className="block w-full px-3 py-1.5 text-left text-[11px] text-gray-700 hover:bg-gray-100"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  handleMoveTask(task.id, column.id, c.id);
+                                  setMoveMenuFor(null);
+                                }}
+                              >
+                                {c.title}
+                              </button>
+                            ))}
+                        </div>
+                      )}
+                      <button
                         className="absolute top-1 right-1 hidden group-hover:inline-flex p-1.5 rounded-[2px] bg-white text-gray-400 hover:bg-gray-100 hover:text-green-600 transition-transform duration-150 hover:scale-110"
                         onClick={(e) => {
                           e.stopPropagation();
@@ -417,6 +448,34 @@ export default function KanbanColumn({
                     }}
                   />
                 </div>
+                <button
+                  className="absolute top-1 right-7 hidden group-hover:inline-flex p-1.5 rounded-[2px] bg-white text-gray-400 hover:bg-gray-100 hover:text-blue-600 transition-transform duration-150 hover:scale-110"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setMoveMenuFor(moveMenuFor === task.id ? null : task.id);
+                  }}
+                >
+                  <ArrowRight className="w-4 h-4" />
+                </button>
+                {moveMenuFor === task.id && (
+                  <div className="absolute top-8 right-1 z-20 rounded-[2px] border border-gray-200 bg-white shadow-md">
+                    {columns
+                      .filter((c) => c.id !== column.id)
+                      .map((c) => (
+                        <button
+                          key={c.id}
+                          className="block w-full px-3 py-1.5 text-left text-[11px] text-gray-700 hover:bg-gray-100"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleMoveTask(task.id, column.id, c.id);
+                            setMoveMenuFor(null);
+                          }}
+                        >
+                          {c.title}
+                        </button>
+                      ))}
+                  </div>
+                )}
                 <button
                   className="absolute top-1 right-1 hidden group-hover:inline-flex p-1.5 rounded-[2px] bg-white text-gray-400 hover:bg-gray-100 hover:text-green-600 transition-transform duration-150 hover:scale-110"
                   onClick={(e) => {


### PR DESCRIPTION
## Summary
- add hover move button with dropdown to reassign tasks to other columns
- implement `handleMoveTask` to update board state when relocating tasks

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68a18ffa8f54832d9d520f52d23d4a54