### PR TITLE
feat: add quick move action to kanban cards

### DIFF
--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -665,6 +665,17 @@ export default function KanbanBoard() {
     await saveBoard({ tasks: nextTasks as any, columns: nextColumns });
   };
 
+  // Quick move without drag-and-drop
+  const handleQuickMove = async (
+    task: TaskSummary,
+    sourceColumnId: string,
+    targetColumnId: string
+  ) => {
+    setDraggedTask(task);
+    setDragSourceColumnId(sourceColumnId);
+    await handleDrop({ preventDefault() {}, stopPropagation() {} } as any, targetColumnId);
+  };
+
   // Toggle "pending" drawer
   const togglePending = (columnId: string) => {
     setOpenPending((prev) => ({ ...prev, [columnId]: !prev[columnId] }));
@@ -970,6 +981,7 @@ export default function KanbanBoard() {
                   handleDragEnterColumn={handleDragEnterColumn}
                   handleDragLeaveColumn={handleDragLeaveColumn}
                   handleDrop={handleDrop}
+                  handleQuickMove={handleQuickMove}
                   dragOverColumn={dragOverColumn}
                   dropIndicatorIndex={dropIndicatorIndex}
                   addPickerOpenFor={addPickerOpenFor}


### PR DESCRIPTION
## Summary
- add quick move handler to move tasks between columns without dragging
- expose quick move option in KanbanColumn with hover button and column selector

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a18ffa8f54832d9d520f52d23d4a54