### PR TITLE
fix: show manufacturing view for inspection users

### DIFF
--- a/taintedpaint/app/holistic/page.tsx
+++ b/taintedpaint/app/holistic/page.tsx
@@ -69,7 +69,7 @@ export default function ArchivePage() {
       try {
         const u = JSON.parse(user);
         const dept = u.department || '';
-        setViewMode(['商务', '检验'].includes(dept) ? 'business' : 'production');
+        setViewMode(dept === '商务' ? 'business' : 'production');
       } catch {}
       setReady(true);
     }

--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -20,7 +20,7 @@ import { Check } from "lucide-react";
 export default function KanbanBoard() {
   const storedUser = typeof window !== "undefined" ? localStorage.getItem("user") : null;
   const department = storedUser ? JSON.parse(storedUser).department : "";
-  const viewMode: "business" | "production" = ["商务", "检验"].includes(department)
+  const viewMode: "business" | "production" = department === "商务"
     ? "business"
     : "production";
   const isRestricted = storedUser ? !!JSON.parse(storedUser).restricted : false;


### PR DESCRIPTION
## Summary
- Treat inspection department as production view instead of business view
- Update holistic archive page and kanban board view mode logic

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68a1999ef780832d8300287145ef7bfb