### PR TITLE
Refactor task flow to remove pending handoff

### DIFF
--- a/taintedpaint/app/api/jobs/route.ts
+++ b/taintedpaint/app/api/jobs/route.ts
@@ -29,7 +29,7 @@ export async function GET(req: NextRequest) {
         {
           id: t.id,
           columnId: t.columnId,
-          previousColumnId: t.previousColumnId,
+          inProgress: t.inProgress,
           customerName: t.customerName,
           representative: t.representative,
           inquiryDate: t.inquiryDate,
@@ -72,6 +72,7 @@ export async function POST(req: NextRequest) {
     const newTask: Task = {
       id: taskId,
       columnId: START_COLUMN_ID,
+      inProgress: false,
       customerName: customerName.trim() || undefined,
       representative: representative.trim() || undefined,
       inquiryDate: inquiryDate.trim() || undefined,

--- a/taintedpaint/app/holistic/page.tsx
+++ b/taintedpaint/app/holistic/page.tsx
@@ -89,7 +89,7 @@ export default function ArchivePage() {
           setColumns(
             baseColumns.map(b => {
               const saved = map.get(b.id);
-              return { ...b, ...saved, pendingTaskIds: saved?.pendingTaskIds || [] };
+              return { ...b, ...saved, taskIds: saved?.taskIds || [] };
             })
           );
         }

--- a/taintedpaint/lib/baseColumns.ts
+++ b/taintedpaint/lib/baseColumns.ts
@@ -7,20 +7,20 @@ export const ARCHIVE_COLUMN_ID = "archive";
 
 // Updated to use taskIds
 export const baseColumns: Column[] = [
-  { id: "create",      title: "建单",   taskIds: [], pendingTaskIds: [] },
-  { id: "quote",       title: "报价",   taskIds: [], pendingTaskIds: [] },
-  { id: "send",        title: "发出",   taskIds: [], pendingTaskIds: [] },
-  { id: "archive",     title: "报价归档",   taskIds: [], pendingTaskIds: [] },
-  { id: "sheet",       title: "制单",   taskIds: [], pendingTaskIds: [] },
-  { id: "approval",    title: "审批",   taskIds: [], pendingTaskIds: [] },
-  { id: "outsourcing", title: "外协",   taskIds: [], pendingTaskIds: [] },
-  { id: "daohe",      title: "道禾",   taskIds: [], pendingTaskIds: [] },
-  { id: "program",     title: "编程",   taskIds: [], pendingTaskIds: [] },
-  { id: "operate",     title: "操机",   taskIds: [], pendingTaskIds: [] },
-  { id: "manual",      title: "手工",   taskIds: [], pendingTaskIds: [] },
-  { id: "batch",       title: "批量",   taskIds: [], pendingTaskIds: [] },
-  { id: "surface",     title: "表面处理",   taskIds: [], pendingTaskIds: [] },
-  { id: "inspect",     title: "检验",   taskIds: [], pendingTaskIds: [] },
-  { id: "ship",        title: "出货",   taskIds: [], pendingTaskIds: [] },
-  { id: "archive2",    title: "完成归档",   taskIds: [], pendingTaskIds: [] }
+  { id: "create",      title: "建单",   taskIds: [] },
+  { id: "quote",       title: "报价",   taskIds: [] },
+  { id: "send",        title: "发出",   taskIds: [] },
+  { id: "archive",     title: "报价归档",   taskIds: [] },
+  { id: "sheet",       title: "制单",   taskIds: [] },
+  { id: "approval",    title: "审批",   taskIds: [] },
+  { id: "outsourcing", title: "外协",   taskIds: [] },
+  { id: "daohe",      title: "道禾",   taskIds: [] },
+  { id: "program",     title: "编程",   taskIds: [] },
+  { id: "operate",     title: "操机",   taskIds: [] },
+  { id: "manual",      title: "手工",   taskIds: [] },
+  { id: "batch",       title: "批量",   taskIds: [] },
+  { id: "surface",     title: "表面处理",   taskIds: [] },
+  { id: "inspect",     title: "检验",   taskIds: [] },
+  { id: "ship",        title: "出货",   taskIds: [] },
+  { id: "archive2",    title: "完成归档",   taskIds: [] }
 ];

--- a/taintedpaint/lib/boardDataStore.ts
+++ b/taintedpaint/lib/boardDataStore.ts
@@ -31,15 +31,6 @@ function normalizeBoardData(data: BoardData) {
 
   // Normalize task arrays in columns
   for (const col of data.columns) {
-    col.pendingTaskIds = Array.from(
-      new Set(
-        (col.pendingTaskIds || []).filter(id => {
-          const t = (data.tasks as Record<string, any>)[id]
-          return !!t
-        })
-      )
-    )
-
     col.taskIds = Array.from(
       new Set(
         col.taskIds.filter(id => {

--- a/taintedpaint/types.ts
+++ b/taintedpaint/types.ts
@@ -2,9 +2,9 @@
 
 export interface Task {
   id: string;
-  columnId: string; // <-- NEW
-  /** Previous column when awaiting acceptance */
-  previousColumnId?: string;
+  columnId: string;
+  /** Whether someone has confirmed they are working on this task */
+  inProgress?: boolean;
   customerName?: string;
   representative?: string;
   inquiryDate?: string;
@@ -35,7 +35,7 @@ export interface TaskHistoryEntry {
 export interface TaskSummary {
   id: string;
   columnId: string;
-  previousColumnId?: string;
+  inProgress?: boolean;
   customerName?: string;
   representative?: string;
   inquiryDate?: string;
@@ -54,9 +54,7 @@ export interface TaskSummary {
 export interface Column {
   id: string;
   title: string;
-  taskIds: string[]; // <-- CHANGED from tasks: Task[]
-  /** Tasks waiting to be accepted for this column */
-  pendingTaskIds: string[];
+  taskIds: string[];
 }
 
 // NEW: A type for the entire board data


### PR DESCRIPTION
## Summary
- remove pending task queues and move cards directly between columns
- add `inProgress` flag and confirmation button for starting work
- simplify board data and column definitions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3eff6dcb0832daf1e334db8f3b631