### PR TITLE
Prioritize in-progress tasks in column sorting

### DIFF
--- a/taintedpaint/components/KanbanColumn.tsx
+++ b/taintedpaint/components/KanbanColumn.tsx
@@ -83,6 +83,11 @@ export default function KanbanColumn({
   const archiveGroups = useMemo(() => {
     if (!isArchive) return [];
     const sorted = [...columnTasks].sort((a, b) => {
+      // Ensure in-progress tasks are listed before others
+      const aProgress = !!a.inProgress;
+      const bProgress = !!b.inProgress;
+      if (aProgress && !bProgress) return -1;
+      if (!aProgress && bProgress) return 1;
       const da = a.updatedAt || a.createdAt || "";
       const db = b.updatedAt || b.createdAt || "";
       return db.localeCompare(da);

--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -272,6 +272,11 @@ export default function KanbanBoard() {
     return [...ids].sort((a, b) => {
       const ta = taskMap[a];
       const tb = taskMap[b];
+      // Tasks that are marked as in progress should always appear before those that are not
+      const aProgress = !!ta?.inProgress;
+      const bProgress = !!tb?.inProgress;
+      if (aProgress && !bProgress) return -1;
+      if (!aProgress && bProgress) return 1;
       const hasDa = ta?.deliveryDate;
       const hasDb = tb?.deliveryDate;
       if (hasDa && !hasDb) return -1;


### PR DESCRIPTION
## Summary
- Ensure `inProgress` tasks are ordered before others in general column sorting
- Make archive column sorting favor tasks marked as in progress

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a3fb27638c832dbbe100ae75f737bc