### PR TITLE
Highlight active task and keep it visible

### DIFF
--- a/taintedpaint/kanban-board.tsx
+++ b/taintedpaint/kanban-board.tsx
@@ -43,6 +43,7 @@ export default function KanbanBoard() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [userName, setUserName] = useState("");
   const [highlightTaskId, setHighlightTaskId] = useState<string | null>(null);
+  const [lastInteractedTaskId, setLastInteractedTaskId] = useState<string | null>(null);
   const [activeFilter, setActiveFilter] = useState<
     null | "active" | "dueToday" | "overdue" | "inactive8h"
   >(null);
@@ -695,6 +696,8 @@ export default function KanbanBoard() {
       },
     };
     setTasks(nextTasks);
+    setLastInteractedTaskId(taskId);
+    setHighlightTaskId(taskId);
     await saveBoard({ tasks: nextTasks as any, columns });
   };
 
@@ -722,6 +725,8 @@ export default function KanbanBoard() {
   const handleTaskClick = async (task: Task, columnId: string, e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
+    setLastInteractedTaskId(task.id);
+    setHighlightTaskId(task.id);
     const column = columns.find((c) => c.id === columnId);
     setSelectedTaskColumnTitle(column ? column.title : null);
     try {
@@ -740,6 +745,10 @@ export default function KanbanBoard() {
 
   const closeModal = () => {
     setIsModalOpen(false);
+    if (lastInteractedTaskId) {
+      setHighlightTaskId(null);
+      setTimeout(() => setHighlightTaskId(lastInteractedTaskId), 0);
+    }
     setTimeout(() => {
       setSelectedTask(null);
       setSelectedTaskColumnTitle(null);


### PR DESCRIPTION
## Summary
- Track last interacted task and spotlight it when starting work or closing the modal
- Automatically scroll to the active card so it remains in view

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a411f980a4832d9821351e978cdb64