### PR TITLE
Handle job file uploads in initial request

### DIFF
--- a/taintedpaint/components/CreateJobForm.tsx
+++ b/taintedpaint/components/CreateJobForm.tsx
@@ -88,15 +88,22 @@ export default function CreateJobForm({ onJobCreated }: CreateJobFormProps) {
   const handleCreateJob = async () => {
     setIsCreating(true)
     try {
-    const formData = new FormData()
+      const formData = new FormData()
 
-    formData.append("customerName", customerName.trim())
-    formData.append("representative", representative.trim())
-    formData.append("inquiryDate", inquiryDate.trim())
-    formData.append("deliveryDate", deliveryDate.trim())
-    formData.append("ynmxId", ynmxId.trim())
-    formData.append("notes", notes.trim())
-    formData.append("updatedBy", userName)
+      formData.append("customerName", customerName.trim())
+      formData.append("representative", representative.trim())
+      formData.append("inquiryDate", inquiryDate.trim())
+      formData.append("deliveryDate", deliveryDate.trim())
+      formData.append("ynmxId", ynmxId.trim())
+      formData.append("notes", notes.trim())
+      formData.append("updatedBy", userName)
+
+      if (selectedFiles && selectedFiles.length > 0) {
+        Array.from(selectedFiles).forEach((f) => {
+          const rel = (f as any).webkitRelativePath || f.name
+          formData.append("files", f, rel)
+        })
+      }
 
       const res = await fetch("/api/jobs", {
         method: "POST",
@@ -105,23 +112,7 @@ export default function CreateJobForm({ onJobCreated }: CreateJobFormProps) {
 
       if (!res.ok) throw new Error("服务端错误")
 
-      let newTask: Task = await res.json()
-
-      if (selectedFiles && selectedFiles.length > 0) {
-        const uploadData = new FormData()
-        Array.from(selectedFiles).forEach(f => {
-          const rel = (f as any).webkitRelativePath || f.name
-          uploadData.append("files", f, rel)
-        })
-        uploadData.append("updatedBy", userName)
-        const uploadRes = await fetch(`/api/jobs/${newTask.id}/upload`, {
-          method: "POST",
-          body: uploadData,
-        })
-        if (uploadRes.ok) {
-          newTask = await uploadRes.json()
-        }
-      }
+      const newTask: Task = await res.json()
 
       onJobCreated(newTask)
 


### PR DESCRIPTION
## Summary
- send job metadata and files together from CreateJobForm
- atomically write uploaded files and create job entry once saves succeed

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68aa8a36ed00832d8ef330efec9152c6