### PR TITLE
Handle locked file errors during upload

### DIFF
--- a/taintedpaint/components/CreateJobForm.tsx
+++ b/taintedpaint/components/CreateJobForm.tsx
@@ -106,7 +106,14 @@ export default function CreateJobForm({ onJobCreated }: CreateJobFormProps) {
         method: "POST",
         body: form,
       })
-      if (!res.ok) throw new Error("upload failed")
+      if (!res.ok) {
+        let message = "文件上传失败，请重试"
+        try {
+          const data = await res.json()
+          if (data?.error) message = data.error
+        } catch {}
+        throw new Error(message)
+      }
       latest = await res.json()
       setUploadIndex(i + 1)
       setUploadProgress(Math.round(((i + 1) / filesArr.length) * 100))
@@ -145,8 +152,8 @@ export default function CreateJobForm({ onJobCreated }: CreateJobFormProps) {
       if (selectedFiles && selectedFiles.length > 0) {
         try {
           finalTask = await uploadFilesSequentially(newTask.id)
-        } catch (e) {
-          setErrorMsg("文件上传失败，请重试")
+        } catch (e: any) {
+          setErrorMsg(e?.message || "文件上传失败，请重试")
           setResumeTask(newTask)
           return
         }
@@ -192,9 +199,9 @@ export default function CreateJobForm({ onJobCreated }: CreateJobFormProps) {
       setUploadProgress(0)
       setUploadIndex(0)
       if (fileInputRef.current) fileInputRef.current.value = ""
-    } catch (e) {
+    } catch (e: any) {
       console.error("继续上传失败", e)
-      setErrorMsg("文件上传失败，请重试")
+      setErrorMsg(e?.message || "文件上传失败，请重试")
     } finally {
       setIsCreating(false)
     }


### PR DESCRIPTION
## Summary
- Catch EACCES/EBUSY errors when saving uploaded files and return a helpful message
- Surface server file-lock errors on the client and allow retry after release

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aabbdc2274832da06d2e9195af7231