### PR TITLE
feat: add delivery date range filter

### DIFF
--- a/taintedpaint/components/AppShell.tsx
+++ b/taintedpaint/components/AppShell.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { useEffect, useState } from "react"
-import { Search, RotateCw, X } from "lucide-react"
+import { Search, RotateCw, X, CalendarRange } from "lucide-react"
 import AccountButton from "@/components/AccountButton"
 
 export default function AppShell({ children }: { children: React.ReactNode }) {
@@ -11,6 +11,9 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
   const isBoard = pathname === "/"
   const [search, setSearch] = useState("")
   const [isRefreshing, setIsRefreshing] = useState(false)
+  const [isDatePickerOpen, setIsDatePickerOpen] = useState(false)
+  const [deliveryStart, setDeliveryStart] = useState("")
+  const [deliveryEnd, setDeliveryEnd] = useState("")
 
   // Listen to board refresh state to animate the header refresh icon
   useEffect(() => {
@@ -26,6 +29,14 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
   const dispatchSearch = (value: string) => {
     try {
       window.dispatchEvent(new CustomEvent("board:search", { detail: value }))
+    } catch {}
+  }
+
+  const dispatchDeliveryRange = (start: string, end: string) => {
+    try {
+      window.dispatchEvent(
+        new CustomEvent("board:deliveryRange", { detail: { start, end } })
+      )
     } catch {}
   }
 
@@ -60,9 +71,16 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
                     placeholder="搜索客户、负责人或ID…"
                     value={search}
                     onChange={(e) => { setSearch(e.target.value); dispatchSearch(e.target.value) }}
-                    className="w-64 px-8 py-2 text-sm rounded-xl bg-white/60 backdrop-blur border apple-border-light focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    className="w-64 pl-8 pr-20 py-2 text-sm rounded-xl bg-white/60 backdrop-blur border apple-border-light focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                   />
                   <Search className="w-4 h-4 text-gray-400 absolute left-2.5 top-1/2 -translate-y-1/2" />
+                  <button
+                    onClick={() => setIsDatePickerOpen((o) => !o)}
+                    className="absolute right-8 top-1/2 -translate-y-1/2 p-1 rounded hover:bg-white/70"
+                    aria-label="按交期过滤"
+                  >
+                    <CalendarRange className="w-4 h-4 text-gray-400" />
+                  </button>
                   {search && (
                     <button
                       onClick={() => { setSearch(""); dispatchSearch("") }}
@@ -71,6 +89,47 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
                     >
                       <X className="w-3.5 h-3.5 text-gray-400" />
                     </button>
+                  )}
+                  {isDatePickerOpen && (
+                    <div className="absolute right-0 mt-2 w-72 p-3 rounded-lg bg-white/90 backdrop-blur border apple-border-light shadow flex flex-col gap-2 z-50">
+                      <div className="flex items-center gap-2">
+                        <input
+                          type="date"
+                          value={deliveryStart}
+                          onChange={(e) => setDeliveryStart(e.target.value)}
+                          className="flex-1 px-2 py-1 text-sm border apple-border-light rounded"
+                        />
+                        <span className="text-gray-500">—</span>
+                        <input
+                          type="date"
+                          value={deliveryEnd}
+                          onChange={(e) => setDeliveryEnd(e.target.value)}
+                          className="flex-1 px-2 py-1 text-sm border apple-border-light rounded"
+                        />
+                      </div>
+                      <div className="flex justify-end gap-2 text-sm">
+                        <button
+                          onClick={() => {
+                            setDeliveryStart("")
+                            setDeliveryEnd("")
+                            dispatchDeliveryRange("", "")
+                            setIsDatePickerOpen(false)
+                          }}
+                          className="px-2 py-1 rounded hover:bg-gray-100"
+                        >
+                          清除
+                        </button>
+                        <button
+                          onClick={() => {
+                            dispatchDeliveryRange(deliveryStart, deliveryEnd)
+                            setIsDatePickerOpen(false)
+                          }}
+                          className="px-2 py-1 rounded bg-blue-500 text-white hover:bg-blue-600"
+                        >
+                          确定
+                        </button>
+                      </div>
+                    </div>
                   )}
               </div>
             )}


### PR DESCRIPTION
## Summary
- add calendar icon with date range popover to board search
- dispatch delivery date range to kanban board for filtering
- filter tasks by selected 交期 range

## Testing
- `npm test`
- `npm run lint` *(fails: requires ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b16aa6bd88832db9c4554fc2c4bd97