### PR TITLE
feat: show search result count and fix task stats

### DIFF
--- a/taintedpaint/components/AppShell.tsx
+++ b/taintedpaint/components/AppShell.tsx
@@ -14,6 +14,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
   const [isDatePickerOpen, setIsDatePickerOpen] = useState(false)
   const [deliveryStart, setDeliveryStart] = useState("")
   const [deliveryEnd, setDeliveryEnd] = useState("")
+  const [resultCount, setResultCount] = useState<number | null>(null)
 
   // Listen to board refresh state to animate the header refresh icon
   useEffect(() => {
@@ -24,6 +25,15 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
     }
     window.addEventListener("board:refreshing" as any, onRefreshing as any)
     return () => window.removeEventListener("board:refreshing" as any, onRefreshing as any)
+  }, [])
+
+  useEffect(() => {
+    const onCount = (e: Event) => {
+      const ce = e as unknown as CustomEvent<number>
+      setResultCount(ce.detail)
+    }
+    window.addEventListener("board:resultCount" as any, onCount as any)
+    return () => window.removeEventListener("board:resultCount" as any, onCount as any)
   }, [])
 
   const dispatchSearch = (value: string) => {
@@ -64,7 +74,8 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
           </div>
           <div className="flex items-center gap-3">
             {isBoard && (
-              <div className="relative hidden sm:block">
+              <div className="relative hidden sm:flex items-center">
+                <div className="relative">
                   <input
                     id="board-search"
                     type="text"
@@ -131,6 +142,12 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
                       </div>
                     </div>
                   )}
+                </div>
+                {( (search || deliveryStart || deliveryEnd) && resultCount !== null) && (
+                  <span className="ml-2 text-xs text-gray-500 whitespace-nowrap">
+                    {resultCount} 条结果
+                  </span>
+                )}
               </div>
             )}
             <AccountButton />


### PR DESCRIPTION
## Summary
- show how many tasks match search or date filters next to the board search field
- correct task statistics by counting unique tasks from visible columns

## Testing
- `npm test`
- `npm run lint` *(fails: If you set up ESLint yourself, we recommend adding the Next.js ESLint plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68b1707472bc832dbafc1c63b8eab802